### PR TITLE
ATT-6: Handling small thumbnail file.

### DIFF
--- a/api/src/main/java/org/openmrs/module/attachments/obs/AbstractAttachmentHandler.java
+++ b/api/src/main/java/org/openmrs/module/attachments/obs/AbstractAttachmentHandler.java
@@ -72,8 +72,12 @@ public abstract class AbstractAttachmentHandler implements ComplexObsHandler {
 		return parent;
 	}
 	
+	public static boolean isThumbnail(String fileName) {
+		return StringUtils.endsWith(FilenameUtils.removeExtension(fileName), NO_THUMBNAIL_SUFFIX);
+	}
+	
 	/*
-	 * Appends "___nothumb__" the file
+	 * Appends NO_THUMBNAIL_SUFFIX the file
 	 */
 	protected static String buildNoThumbnailFileFileName(String fileName) {
 		if (StringUtils.endsWith(FilenameUtils.removeExtension(fileName), NO_THUMBNAIL_SUFFIX)) {
@@ -85,7 +89,7 @@ public abstract class AbstractAttachmentHandler implements ComplexObsHandler {
 	}
 	
 	/*
-	 * Appends "_thumb" the file
+	 * Appends THUMBNAIL_SUFFIX the file
 	 */
 	public static String buildThumbnailFileName(String fileName) {
 		return FilenameUtils.removeExtension(fileName) + "_thumb" + "." + FilenameUtils.getExtension(fileName);
@@ -108,16 +112,12 @@ public abstract class AbstractAttachmentHandler implements ComplexObsHandler {
 		
 		String savedFileName = savedFile.getName();
 		
-		// Check for small image file
 		if ((imageHeight <= THUMBNAIL_MAX_HEIGHT) && (imageWidth <= THUMBNAIL_MAX_WIDTH)) {
-			// Rename the file by append NO_THUMBNAIL_SUFFIX to the file.
-			// Therefore, we will know this is a small file and no need for thumnail.
 			String newSavedFileName = buildNoThumbnailFileFileName(savedFile.getAbsolutePath());
 			File newSavedFile = new File(newSavedFileName);
 			savedFile.renameTo(newSavedFile);
 			savedFileName = buildNoThumbnailFileFileName(savedFileName);
 		} else {
-			// Saving the thumbnail
 			File dir = savedFile.getParentFile();
 			String thumbnailFileName = buildThumbnailFileName(savedFileName);
 			try {

--- a/api/src/main/java/org/openmrs/module/attachments/obs/AbstractAttachmentHandler.java
+++ b/api/src/main/java/org/openmrs/module/attachments/obs/AbstractAttachmentHandler.java
@@ -18,192 +18,197 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 
 /**
- * Double inheritance class. The actual implementation parent must be set
- * through {@link #setParentComplexObsHandler()}.
+ * Double inheritance class. The actual implementation parent must be set through
+ * {@link #setParentComplexObsHandler()}.
  */
 public abstract class AbstractAttachmentHandler implements ComplexObsHandler {
-
-    public final static String NO_THUMBNAIL_SUFFIX = "___nothumb__";
-    public final static String THUMBNAIL_SUFFIX = "_thumb";
-
-    protected final Log log = LogFactory.getLog(getClass());
-
-    private ComplexObsHandler parent;
-
-    @Autowired
-    @Qualifier(AttachmentsConstants.COMPONENT_COMPLEXDATA_HELPER)
-    private ComplexDataHelper complexDataHelper;
-
-    public AbstractAttachmentHandler() {
-        super();
-        setParentComplexObsHandler();
-    }
-
-    protected ComplexDataHelper getComplexDataHelper() {
-        return complexDataHelper;
-    }
-
-    /*
-     * To set the "real" implementation parent.
-     */
-    abstract protected void setParentComplexObsHandler();
-
-    /*
-     * Complex data CRUD - Read
-     */
-    abstract protected ComplexData readComplexData(Obs obs, ValueComplex valueComplex, String view);
-
-    /*
-     * Complex data CRUD - Delete
-     */
-    abstract protected boolean deleteComplexData(Obs obs, AttachmentComplexData complexData);
-
-    /*
-     * Complex data CRUD - Save (Update)
-     */
-    abstract protected ValueComplex saveComplexData(Obs obs, AttachmentComplexData complexData);
-
-    protected void setParent(ComplexObsHandler complexObsHandler) {
-        this.parent = complexObsHandler;
-    }
-
-    final protected ComplexObsHandler getParent() {
-        return parent;
-    }
-
-    /*
-     * Appends "___nothumb__" the file
-     */
-    protected static String buildNoThumbnailFileFileName(String fileName) {
-        if (StringUtils.endsWith(FilenameUtils.removeExtension(fileName), NO_THUMBNAIL_SUFFIX)) {
-            return fileName;
-        } else {
-            return FilenameUtils.removeExtension(fileName) + NO_THUMBNAIL_SUFFIX + "." + FilenameUtils.getExtension(fileName);
-        }
-    }
-
-    /*
-     * Appends "_thumb" the file
-     */
-    public static String buildThumbnailFileName(String fileName) {
-        return FilenameUtils.removeExtension(fileName) + "_thumb" + "." + FilenameUtils.getExtension(fileName);
-    }
-
-    /**
-     * <p>The saveThumbnailOrRename method checks image dimension to see if the
-     * image is small enough to be its own thumbnail. If so, it will rename the
-     * image file by appending the <b>NO_THUMBNAIL_SUFFIX</b> to the file.
-     * Otherewise, it will create a small thumbnail file alongside the original
-     * file to be used as thumbnail image.</p>
-     *
-     * @param savedFile original file pointer
-     * @param imageHight image hight
-     * @param imageWidth image width
-     * @return savedFileName new renamed file name or orignal file name
-     */
-    public static String saveThumbnailOrRename(File savedFile, int imageHeight, int imageWidth) {
-
-        String savedFileName = savedFile.getName();
-
-        // Check for small image file
-        if ((imageHeight <= THUMBNAIL_MAX_HEIGHT) && (imageWidth <= THUMBNAIL_MAX_WIDTH)) {
-            // Rename the file by append NO_THUMBNAIL_SUFFIX to the file.
-            // Therefore, we will know this is a small file and no need for thumnail.
-            String newSavedFileName = buildNoThumbnailFileFileName(savedFile.getAbsolutePath());
-            File newSavedFile = new File(newSavedFileName);
-            savedFile.renameTo(newSavedFile);
-            savedFileName = buildNoThumbnailFileFileName(savedFileName);
-        } else {
-            // Saving the thumbnail
-            File dir = savedFile.getParentFile();
-            String thumbnailFileName = buildThumbnailFileName(savedFileName);
-            try {
-                Thumbnails.of(savedFile.getAbsolutePath()).size(THUMBNAIL_MAX_HEIGHT, THUMBNAIL_MAX_WIDTH).toFile(new File(dir, thumbnailFileName));
-            } catch (IOException e) {
-                throw new APIException("A thumbnail file could not be saved for obs with", e);
-            }
-        }
-
-        return savedFileName;
-    }
-
-    /**
-     * @param complexData An obs's complex data.
-     * @return null if this is not our implementation, the custom
-     * {@link DocumentComplexData_old} otherwise.
-     */
-    public static AttachmentComplexData fetchAttachmentComplexData(ComplexData complexData) {
-
-        if ((complexData instanceof AttachmentComplexData) == false) {
-            return null;
-        }
-
-        AttachmentComplexData docData = (AttachmentComplexData) complexData;
-        String instructions = docData.getInstructions();
-        if (instructions.equals(ValueComplex.INSTRUCTIONS_NONE)) {
-            return null;
-        }
-
-        return docData;
-    }
-
-    /*
-     * Drifts to our own CRUD overloadable routine when it is our implementation.
-     */
-    @Override
-    final public Obs getObs(Obs obs, String view) {
-
-        ValueComplex valueComplex = new ValueComplex(obs.getValueComplex());
-        if (valueComplex.isOwnImplementation() == false) { // not our implementation
-            return getParent().getObs(obs, view);
-        }
-
-        if (StringUtils.isEmpty(view)) {
-            view = AttachmentsConstants.ATT_VIEW_ORIGINAL;
-        }
-
-        ComplexData docData = readComplexData(obs, valueComplex, view);
-        obs.setComplexData(docData);
-        return obs;
-    }
-
-    /*
-     * Drifts to our own CRUD overloadable routine when it is our implementation.
-     */
-    @Override
-    final public boolean purgeComplexData(Obs obs) {
-
-        AttachmentComplexData complexData = fetchAttachmentComplexData(obs.getComplexData());
-        if (complexData == null) { // not our implementation
-            if (obs.getComplexData() == null) {
-                log.error("Complex data was null and hence was not purged for OBS_ID='" + obs.getObsId() + "'.");
-                return false;
-            } else {
-                return getParent().purgeComplexData(obs);
-            }
-        }
-
-        return deleteComplexData(obs, complexData);
-    }
-
-    /*
-     * Drifts to our own CRUD overloadable routine when it is our implementation.
-     */
-    @Override
-    final public Obs saveObs(Obs obs) {
-
-        AttachmentComplexData complexData = fetchAttachmentComplexData(obs.getComplexData());
-        if (complexData == null) { // not our implementation
-            if (obs.getComplexData() == null) {
-                log.error("Complex data was null and hence was not saved for OBS_ID='" + obs.getObsId() + "'.");
-                return obs;
-            } else {
-                return getParent().saveObs(obs);
-            }
-        }
-
-        ValueComplex valueComplex = saveComplexData(obs, complexData);
-        obs.setValueComplex(valueComplex.getValueComplex());
-        return obs;
-    }
+	
+	public final static String NO_THUMBNAIL_SUFFIX = "___nothumb__";
+	
+	public final static String THUMBNAIL_SUFFIX = "_thumb";
+	
+	protected final Log log = LogFactory.getLog(getClass());
+	
+	private ComplexObsHandler parent;
+	
+	@Autowired
+	@Qualifier(AttachmentsConstants.COMPONENT_COMPLEXDATA_HELPER)
+	private ComplexDataHelper complexDataHelper;
+	
+	public AbstractAttachmentHandler() {
+		super();
+		setParentComplexObsHandler();
+	}
+	
+	protected ComplexDataHelper getComplexDataHelper() {
+		return complexDataHelper;
+	}
+	
+	/*
+	 * To set the "real" implementation parent.
+	 */
+	abstract protected void setParentComplexObsHandler();
+	
+	/*
+	 * Complex data CRUD - Read
+	 */
+	abstract protected ComplexData readComplexData(Obs obs, ValueComplex valueComplex, String view);
+	
+	/*
+	 * Complex data CRUD - Delete
+	 */
+	abstract protected boolean deleteComplexData(Obs obs, AttachmentComplexData complexData);
+	
+	/*
+	 * Complex data CRUD - Save (Update)
+	 */
+	abstract protected ValueComplex saveComplexData(Obs obs, AttachmentComplexData complexData);
+	
+	protected void setParent(ComplexObsHandler complexObsHandler) {
+		this.parent = complexObsHandler;
+	}
+	
+	final protected ComplexObsHandler getParent() {
+		return parent;
+	}
+	
+	/*
+	 * Appends "___nothumb__" the file
+	 */
+	protected static String buildNoThumbnailFileFileName(String fileName) {
+		if (StringUtils.endsWith(FilenameUtils.removeExtension(fileName), NO_THUMBNAIL_SUFFIX)) {
+			return fileName;
+		} else {
+			return FilenameUtils.removeExtension(fileName) + NO_THUMBNAIL_SUFFIX + "."
+			        + FilenameUtils.getExtension(fileName);
+		}
+	}
+	
+	/*
+	 * Appends "_thumb" the file
+	 */
+	public static String buildThumbnailFileName(String fileName) {
+		return FilenameUtils.removeExtension(fileName) + "_thumb" + "." + FilenameUtils.getExtension(fileName);
+	}
+	
+	/**
+	 * <p>
+	 * The saveThumbnailOrRename method checks image dimension to see if the image is small enough to be
+	 * its own thumbnail. If so, it will rename the image file by appending the
+	 * <b>NO_THUMBNAIL_SUFFIX</b> to the file. Otherewise, it will create a small thumbnail file
+	 * alongside the original file to be used as thumbnail image.
+	 * </p>
+	 *
+	 * @param savedFile original file pointer
+	 * @param imageHight image hight
+	 * @param imageWidth image width
+	 * @return savedFileName new renamed file name or orignal file name
+	 */
+	public static String saveThumbnailOrRename(File savedFile, int imageHeight, int imageWidth) {
+		
+		String savedFileName = savedFile.getName();
+		
+		// Check for small image file
+		if ((imageHeight <= THUMBNAIL_MAX_HEIGHT) && (imageWidth <= THUMBNAIL_MAX_WIDTH)) {
+			// Rename the file by append NO_THUMBNAIL_SUFFIX to the file.
+			// Therefore, we will know this is a small file and no need for thumnail.
+			String newSavedFileName = buildNoThumbnailFileFileName(savedFile.getAbsolutePath());
+			File newSavedFile = new File(newSavedFileName);
+			savedFile.renameTo(newSavedFile);
+			savedFileName = buildNoThumbnailFileFileName(savedFileName);
+		} else {
+			// Saving the thumbnail
+			File dir = savedFile.getParentFile();
+			String thumbnailFileName = buildThumbnailFileName(savedFileName);
+			try {
+				Thumbnails.of(savedFile.getAbsolutePath()).size(THUMBNAIL_MAX_HEIGHT, THUMBNAIL_MAX_WIDTH)
+				        .toFile(new File(dir, thumbnailFileName));
+			}
+			catch (IOException e) {
+				throw new APIException("A thumbnail file could not be saved for obs with", e);
+			}
+		}
+		
+		return savedFileName;
+	}
+	
+	/**
+	 * @param complexData An obs's complex data.
+	 * @return null if this is not our implementation, the custom {@link DocumentComplexData_old}
+	 *         otherwise.
+	 */
+	public static AttachmentComplexData fetchAttachmentComplexData(ComplexData complexData) {
+		
+		if ((complexData instanceof AttachmentComplexData) == false) {
+			return null;
+		}
+		
+		AttachmentComplexData docData = (AttachmentComplexData) complexData;
+		String instructions = docData.getInstructions();
+		if (instructions.equals(ValueComplex.INSTRUCTIONS_NONE)) {
+			return null;
+		}
+		
+		return docData;
+	}
+	
+	/*
+	 * Drifts to our own CRUD overloadable routine when it is our implementation.
+	 */
+	@Override
+	final public Obs getObs(Obs obs, String view) {
+		
+		ValueComplex valueComplex = new ValueComplex(obs.getValueComplex());
+		if (valueComplex.isOwnImplementation() == false) { // not our implementation
+			return getParent().getObs(obs, view);
+		}
+		
+		if (StringUtils.isEmpty(view)) {
+			view = AttachmentsConstants.ATT_VIEW_ORIGINAL;
+		}
+		
+		ComplexData docData = readComplexData(obs, valueComplex, view);
+		obs.setComplexData(docData);
+		return obs;
+	}
+	
+	/*
+	 * Drifts to our own CRUD overloadable routine when it is our implementation.
+	 */
+	@Override
+	final public boolean purgeComplexData(Obs obs) {
+		
+		AttachmentComplexData complexData = fetchAttachmentComplexData(obs.getComplexData());
+		if (complexData == null) { // not our implementation
+			if (obs.getComplexData() == null) {
+				log.error("Complex data was null and hence was not purged for OBS_ID='" + obs.getObsId() + "'.");
+				return false;
+			} else {
+				return getParent().purgeComplexData(obs);
+			}
+		}
+		
+		return deleteComplexData(obs, complexData);
+	}
+	
+	/*
+	 * Drifts to our own CRUD overloadable routine when it is our implementation.
+	 */
+	@Override
+	final public Obs saveObs(Obs obs) {
+		
+		AttachmentComplexData complexData = fetchAttachmentComplexData(obs.getComplexData());
+		if (complexData == null) { // not our implementation
+			if (obs.getComplexData() == null) {
+				log.error("Complex data was null and hence was not saved for OBS_ID='" + obs.getObsId() + "'.");
+				return obs;
+			} else {
+				return getParent().saveObs(obs);
+			}
+		}
+		
+		ValueComplex valueComplex = saveComplexData(obs, complexData);
+		obs.setValueComplex(valueComplex.getValueComplex());
+		return obs;
+	}
 }

--- a/api/src/main/java/org/openmrs/module/attachments/obs/AbstractAttachmentHandler.java
+++ b/api/src/main/java/org/openmrs/module/attachments/obs/AbstractAttachmentHandler.java
@@ -1,148 +1,209 @@
 package org.openmrs.module.attachments.obs;
 
+import java.io.File;
+import java.io.IOException;
+import net.coobird.thumbnailator.Thumbnails;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.openmrs.Obs;
+import org.openmrs.api.APIException;
 import org.openmrs.module.attachments.AttachmentsConstants;
+import static org.openmrs.module.attachments.obs.ImageAttachmentHandler.THUMBNAIL_MAX_HEIGHT;
+import static org.openmrs.module.attachments.obs.ImageAttachmentHandler.THUMBNAIL_MAX_WIDTH;
 import org.openmrs.obs.ComplexData;
 import org.openmrs.obs.ComplexObsHandler;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 
 /**
- * Double inheritance class. The actual implementation parent must be set through
- * {@link #setParentComplexObsHandler()}.
+ * Double inheritance class. The actual implementation parent must be set
+ * through {@link #setParentComplexObsHandler()}.
  */
 public abstract class AbstractAttachmentHandler implements ComplexObsHandler {
-	
-	protected final Log log = LogFactory.getLog(getClass());
-	
-	private ComplexObsHandler parent;
-	
-	@Autowired
-	@Qualifier(AttachmentsConstants.COMPONENT_COMPLEXDATA_HELPER)
-	private ComplexDataHelper complexDataHelper;
-	
-	public AbstractAttachmentHandler() {
-		super();
-		setParentComplexObsHandler();
-	}
-	
-	protected ComplexDataHelper getComplexDataHelper() {
-		return complexDataHelper;
-	}
-	
-	/*
-	 * To set the "real" implementation parent.
-	 */
-	abstract protected void setParentComplexObsHandler();
-	
-	/*
-	 * Complex data CRUD - Read
-	 */
-	abstract protected ComplexData readComplexData(Obs obs, ValueComplex valueComplex, String view);
-	
-	/*
-	 * Complex data CRUD - Delete
-	 */
-	abstract protected boolean deleteComplexData(Obs obs, AttachmentComplexData complexData);
-	
-	/*
-	 * Complex data CRUD - Save (Update)
-	 */
-	abstract protected ValueComplex saveComplexData(Obs obs, AttachmentComplexData complexData);
-	
-	protected void setParent(ComplexObsHandler complexObsHandler) {
-		this.parent = complexObsHandler;
-	}
-	
-	final protected ComplexObsHandler getParent() {
-		return parent;
-	}
-	
-	public static String buildThumbnailFileName(String fileName) {
-		return FilenameUtils.removeExtension(fileName) + "_thumb" + "." + FilenameUtils.getExtension(fileName);
-	}
-	
-	/**
-	 * @param complexData An obs's complex data.
-	 * @return null if this is not our implementation, the custom {@link DocumentComplexData_old}
-	 *         otherwise.
-	 */
-	public static AttachmentComplexData fetchAttachmentComplexData(ComplexData complexData) {
-		
-		if ((complexData instanceof AttachmentComplexData) == false) {
-			return null;
-		}
-		
-		AttachmentComplexData docData = (AttachmentComplexData) complexData;
-		String instructions = docData.getInstructions();
-		if (instructions.equals(ValueComplex.INSTRUCTIONS_NONE)) {
-			return null;
-		}
-		
-		return docData;
-	}
-	
-	/*
-	 * Drifts to our own CRUD overloadable routine when it is our implementation.
-	 */
-	@Override
-	final public Obs getObs(Obs obs, String view) {
-		
-		ValueComplex valueComplex = new ValueComplex(obs.getValueComplex());
-		if (valueComplex.isOwnImplementation() == false) { // not our implementation
-			return getParent().getObs(obs, view);
-		}
-		
-		if (StringUtils.isEmpty(view)) {
-			view = AttachmentsConstants.ATT_VIEW_ORIGINAL;
-		}
-		
-		ComplexData docData = readComplexData(obs, valueComplex, view);
-		obs.setComplexData(docData);
-		return obs;
-	}
-	
-	/*
-	 * Drifts to our own CRUD overloadable routine when it is our implementation.
-	 */
-	@Override
-	final public boolean purgeComplexData(Obs obs) {
-		
-		AttachmentComplexData complexData = fetchAttachmentComplexData(obs.getComplexData());
-		if (complexData == null) { // not our implementation
-			if (obs.getComplexData() == null) {
-				log.error("Complex data was null and hence was not purged for OBS_ID='" + obs.getObsId() + "'.");
-				return false;
-			} else {
-				return getParent().purgeComplexData(obs);
-			}
-		}
-		
-		return deleteComplexData(obs, complexData);
-	}
-	
-	/*
-	 * Drifts to our own CRUD overloadable routine when it is our implementation.
-	 */
-	@Override
-	final public Obs saveObs(Obs obs) {
-		
-		AttachmentComplexData complexData = fetchAttachmentComplexData(obs.getComplexData());
-		if (complexData == null) { // not our implementation
-			if (obs.getComplexData() == null) {
-				log.error("Complex data was null and hence was not saved for OBS_ID='" + obs.getObsId() + "'.");
-				return obs;
-			} else {
-				return getParent().saveObs(obs);
-			}
-		}
-		
-		ValueComplex valueComplex = saveComplexData(obs, complexData);
-		obs.setValueComplex(valueComplex.getValueComplex());
-		return obs;
-	}
+
+    public final static String NO_THUMBNAIL_SUFFIX = "___nothumb__";
+    public final static String THUMBNAIL_SUFFIX = "_thumb";
+
+    protected final Log log = LogFactory.getLog(getClass());
+
+    private ComplexObsHandler parent;
+
+    @Autowired
+    @Qualifier(AttachmentsConstants.COMPONENT_COMPLEXDATA_HELPER)
+    private ComplexDataHelper complexDataHelper;
+
+    public AbstractAttachmentHandler() {
+        super();
+        setParentComplexObsHandler();
+    }
+
+    protected ComplexDataHelper getComplexDataHelper() {
+        return complexDataHelper;
+    }
+
+    /*
+     * To set the "real" implementation parent.
+     */
+    abstract protected void setParentComplexObsHandler();
+
+    /*
+     * Complex data CRUD - Read
+     */
+    abstract protected ComplexData readComplexData(Obs obs, ValueComplex valueComplex, String view);
+
+    /*
+     * Complex data CRUD - Delete
+     */
+    abstract protected boolean deleteComplexData(Obs obs, AttachmentComplexData complexData);
+
+    /*
+     * Complex data CRUD - Save (Update)
+     */
+    abstract protected ValueComplex saveComplexData(Obs obs, AttachmentComplexData complexData);
+
+    protected void setParent(ComplexObsHandler complexObsHandler) {
+        this.parent = complexObsHandler;
+    }
+
+    final protected ComplexObsHandler getParent() {
+        return parent;
+    }
+
+    /*
+     * Appends "___nothumb__" the file
+     */
+    protected static String buildNoThumbnailFileFileName(String fileName) {
+        if (StringUtils.endsWith(FilenameUtils.removeExtension(fileName), NO_THUMBNAIL_SUFFIX)) {
+            return fileName;
+        } else {
+            return FilenameUtils.removeExtension(fileName) + NO_THUMBNAIL_SUFFIX + "." + FilenameUtils.getExtension(fileName);
+        }
+    }
+
+    /*
+     * Appends "_thumb" the file
+     */
+    public static String buildThumbnailFileName(String fileName) {
+        return FilenameUtils.removeExtension(fileName) + "_thumb" + "." + FilenameUtils.getExtension(fileName);
+    }
+
+    /**
+     * <p>The saveThumbnailOrRename method checks image dimension to see if the
+     * image is small enough to be its own thumbnail. If so, it will rename the
+     * image file by appending the <b>NO_THUMBNAIL_SUFFIX</b> to the file.
+     * Otherewise, it will create a small thumbnail file alongside the original
+     * file to be used as thumbnail image.</p>
+     *
+     * @param savedFile original file pointer
+     * @param imageHight image hight
+     * @param imageWidth image width
+     * @return savedFileName new renamed file name or orignal file name
+     */
+    public static String saveThumbnailOrRename(File savedFile, int imageHeight, int imageWidth) {
+
+        String savedFileName = savedFile.getName();
+
+        // Check for small image file
+        if ((imageHeight <= THUMBNAIL_MAX_HEIGHT) && (imageWidth <= THUMBNAIL_MAX_WIDTH)) {
+            // Rename the file by append NO_THUMBNAIL_SUFFIX to the file.
+            // Therefore, we will know this is a small file and no need for thumnail.
+            String newSavedFileName = buildNoThumbnailFileFileName(savedFile.getAbsolutePath());
+            File newSavedFile = new File(newSavedFileName);
+            savedFile.renameTo(newSavedFile);
+            savedFileName = buildNoThumbnailFileFileName(savedFileName);
+        } else {
+            // Saving the thumbnail
+            File dir = savedFile.getParentFile();
+            String thumbnailFileName = buildThumbnailFileName(savedFileName);
+            try {
+                Thumbnails.of(savedFile.getAbsolutePath()).size(THUMBNAIL_MAX_HEIGHT, THUMBNAIL_MAX_WIDTH).toFile(new File(dir, thumbnailFileName));
+            } catch (IOException e) {
+                throw new APIException("A thumbnail file could not be saved for obs with", e);
+            }
+        }
+
+        return savedFileName;
+    }
+
+    /**
+     * @param complexData An obs's complex data.
+     * @return null if this is not our implementation, the custom
+     * {@link DocumentComplexData_old} otherwise.
+     */
+    public static AttachmentComplexData fetchAttachmentComplexData(ComplexData complexData) {
+
+        if ((complexData instanceof AttachmentComplexData) == false) {
+            return null;
+        }
+
+        AttachmentComplexData docData = (AttachmentComplexData) complexData;
+        String instructions = docData.getInstructions();
+        if (instructions.equals(ValueComplex.INSTRUCTIONS_NONE)) {
+            return null;
+        }
+
+        return docData;
+    }
+
+    /*
+     * Drifts to our own CRUD overloadable routine when it is our implementation.
+     */
+    @Override
+    final public Obs getObs(Obs obs, String view) {
+
+        ValueComplex valueComplex = new ValueComplex(obs.getValueComplex());
+        if (valueComplex.isOwnImplementation() == false) { // not our implementation
+            return getParent().getObs(obs, view);
+        }
+
+        if (StringUtils.isEmpty(view)) {
+            view = AttachmentsConstants.ATT_VIEW_ORIGINAL;
+        }
+
+        ComplexData docData = readComplexData(obs, valueComplex, view);
+        obs.setComplexData(docData);
+        return obs;
+    }
+
+    /*
+     * Drifts to our own CRUD overloadable routine when it is our implementation.
+     */
+    @Override
+    final public boolean purgeComplexData(Obs obs) {
+
+        AttachmentComplexData complexData = fetchAttachmentComplexData(obs.getComplexData());
+        if (complexData == null) { // not our implementation
+            if (obs.getComplexData() == null) {
+                log.error("Complex data was null and hence was not purged for OBS_ID='" + obs.getObsId() + "'.");
+                return false;
+            } else {
+                return getParent().purgeComplexData(obs);
+            }
+        }
+
+        return deleteComplexData(obs, complexData);
+    }
+
+    /*
+     * Drifts to our own CRUD overloadable routine when it is our implementation.
+     */
+    @Override
+    final public Obs saveObs(Obs obs) {
+
+        AttachmentComplexData complexData = fetchAttachmentComplexData(obs.getComplexData());
+        if (complexData == null) { // not our implementation
+            if (obs.getComplexData() == null) {
+                log.error("Complex data was null and hence was not saved for OBS_ID='" + obs.getObsId() + "'.");
+                return obs;
+            } else {
+                return getParent().saveObs(obs);
+            }
+        }
+
+        ValueComplex valueComplex = saveComplexData(obs, complexData);
+        obs.setValueComplex(valueComplex.getValueComplex());
+        return obs;
+    }
 }

--- a/api/src/main/java/org/openmrs/module/attachments/obs/ImageAttachmentHandler.java
+++ b/api/src/main/java/org/openmrs/module/attachments/obs/ImageAttachmentHandler.java
@@ -2,7 +2,10 @@ package org.openmrs.module.attachments.obs;
 
 import java.io.File;
 import java.io.IOException;
-
+import java.awt.image.BufferedImage;
+import javax.imageio.ImageIO;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang.StringUtils;
 import org.openmrs.Obs;
 import org.openmrs.api.APIException;
 import org.openmrs.module.attachments.AttachmentsConstants;
@@ -10,81 +13,90 @@ import org.openmrs.obs.ComplexData;
 import org.openmrs.obs.handler.AbstractHandler;
 import org.openmrs.obs.handler.ImageHandler;
 
-import net.coobird.thumbnailator.Thumbnails;
-
 public class ImageAttachmentHandler extends AbstractAttachmentHandler {
-	
-	public final static int THUMBNAIL_MAX_HEIGHT = 200;
-	
-	public final static int THUMBNAIL_MAX_WIDTH = THUMBNAIL_MAX_HEIGHT;
-	
-	public ImageAttachmentHandler() {
-		super();
-	}
-	
-	@Override
-	protected void setParentComplexObsHandler() {
-		setParent(new ImageHandler());
-	}
-	
-	@Override
-	protected ComplexData readComplexData(Obs obs, ValueComplex valueComplex, String view) {
-		
-		String fileName = valueComplex.getFileName();
-		if (view.equals(AttachmentsConstants.ATT_VIEW_THUMBNAIL)) {
-			fileName = buildThumbnailFileName(fileName);
-		}
-		
-		// We invoke the parent to inherit from the file reading routines.
-		Obs tmpObs = new Obs();
-		tmpObs.setValueComplex(fileName); // Temp obs used as a safety
-		tmpObs = getParent().getObs(tmpObs, AttachmentsConstants.IMAGE_HANDLER_VIEW); // ImageHandler doesn't handle
-		                                                                              // several views
-		ComplexData complexData = tmpObs.getComplexData();
-		
-		// Then we build our own custom complex data
-		return getComplexDataHelper().build(valueComplex.getInstructions(), complexData.getTitle(), complexData.getData(),
-		    valueComplex.getMimeType()).asComplexData();
-	}
-	
-	@Override
-	protected boolean deleteComplexData(Obs obs, AttachmentComplexData complexData) {
-		
-		// We use a temp obs whose complex data points to the file names
-		String fileName = complexData.getTitle();
-		String thumbnailFileName = buildThumbnailFileName(fileName);
-		
-		Obs tmpObs = new Obs();
-		tmpObs.setValueComplex(thumbnailFileName);
-		boolean isThumbNailPurged = getParent().purgeComplexData(tmpObs);
-		tmpObs.setValueComplex(fileName);
-		boolean isImagePurged = getParent().purgeComplexData(tmpObs);
-		
-		return isThumbNailPurged && isImagePurged;
-	}
-	
-	@Override
-	protected ValueComplex saveComplexData(Obs obs, AttachmentComplexData complexData) {
-		
-		// We invoke the parent to inherit from the file saving routines.
-		obs = getParent().saveObs(obs);
-		
-		File savedFile = AbstractHandler.getComplexDataFile(obs);
-		String savedFileName = savedFile.getName();
-		
-		// Saving the thumbnail
-		File dir = savedFile.getParentFile();
-		String thumbnailFileName = buildThumbnailFileName(savedFileName);
-		try {
-			Thumbnails.of(savedFile.getAbsolutePath()).size(THUMBNAIL_MAX_HEIGHT, THUMBNAIL_MAX_WIDTH)
-			        .toFile(new File(dir, thumbnailFileName));
-		}
-		catch (IOException e) {
-			getParent().purgeComplexData(obs);
-			throw new APIException("A thumbnail file could not be saved for obs with" + "OBS_ID='" + obs.getObsId() + "', "
-			        + "FILE='" + complexData.getTitle() + "'.", e);
-		}
-		
-		return new ValueComplex(complexData.getInstructions(), complexData.getMimeType(), savedFileName);
-	}
+
+    public final static int THUMBNAIL_MAX_HEIGHT = 200;
+
+    public final static int THUMBNAIL_MAX_WIDTH = THUMBNAIL_MAX_HEIGHT;
+
+    public ImageAttachmentHandler() {
+        super();
+    }
+
+    @Override
+    protected void setParentComplexObsHandler() {
+        setParent(new ImageHandler());
+    }
+
+    @Override
+    protected ComplexData readComplexData(Obs obs, ValueComplex valueComplex, String view) {
+
+        String fileName = valueComplex.getFileName();
+        if (view.equals(AttachmentsConstants.ATT_VIEW_THUMBNAIL)
+                && !StringUtils.endsWith(FilenameUtils.removeExtension(fileName), NO_THUMBNAIL_SUFFIX)) {
+            fileName = buildThumbnailFileName(fileName);
+        }
+
+        // We invoke the parent to inherit from the file reading routines.
+        Obs tmpObs = new Obs();
+        tmpObs.setValueComplex(fileName); // Temp obs used as a safety
+        tmpObs = getParent().getObs(tmpObs, AttachmentsConstants.IMAGE_HANDLER_VIEW); // ImageHandler doesn't handle several views
+        ComplexData complexData = tmpObs.getComplexData();
+
+        // Then we build our own custom complex data
+        return getComplexDataHelper().build(valueComplex.getInstructions(), complexData.getTitle(), complexData.getData(),
+                valueComplex.getMimeType()).asComplexData();
+    }
+
+    @Override
+    protected boolean deleteComplexData(Obs obs, AttachmentComplexData complexData) {
+
+        // We use a temp obs whose complex data points to the file names
+        String fileName = complexData.getTitle();
+        boolean isThumbNailPurged = true;
+        Obs tmpObs = new Obs();
+
+        if (!StringUtils.endsWith(FilenameUtils.removeExtension(fileName), NO_THUMBNAIL_SUFFIX)) {
+            String thumbnailFileName = buildThumbnailFileName(fileName);
+            tmpObs.setValueComplex(thumbnailFileName);
+            isThumbNailPurged = getParent().purgeComplexData(tmpObs);
+        }
+
+        tmpObs.setValueComplex(fileName);
+        boolean isImagePurged = getParent().purgeComplexData(tmpObs);
+
+        return isThumbNailPurged && isImagePurged;
+    }
+
+    @Override
+    protected ValueComplex saveComplexData(Obs obs, AttachmentComplexData complexData) {
+        int imageHeight = Integer.MAX_VALUE;
+        int imageWidth = Integer.MAX_VALUE;
+        String savedFileName = null;
+
+        // We invoke the parent to inherit from the file saving routines.
+        obs = getParent().saveObs(obs);
+
+        File savedFile = AbstractHandler.getComplexDataFile(obs);
+
+        // Get image dimensions
+        try {
+            BufferedImage image = ImageIO.read(savedFile);
+            imageHeight = image.getHeight();
+            imageWidth = image.getWidth();
+        } catch (IOException e) {
+            log.warn("The dimensions of image 'savedFileName' could not be determined, continuing with generating thumbnail.");
+        }
+
+        try {
+            savedFileName = saveThumbnailOrRename(savedFile, imageHeight, imageWidth);
+        } catch (APIException e) {
+            getParent().purgeComplexData(obs);
+            throw new APIException("A thumbnail file could not be saved for obs with"
+                    + "OBS_ID='" + obs.getObsId() + "', "
+                    + "FILE='" + complexData.getTitle() + "'.", e);
+        }
+
+        return new ValueComplex(complexData.getInstructions(), complexData.getMimeType(), savedFileName);
+    }
 }

--- a/api/src/main/java/org/openmrs/module/attachments/obs/ImageAttachmentHandler.java
+++ b/api/src/main/java/org/openmrs/module/attachments/obs/ImageAttachmentHandler.java
@@ -14,89 +14,92 @@ import org.openmrs.obs.handler.AbstractHandler;
 import org.openmrs.obs.handler.ImageHandler;
 
 public class ImageAttachmentHandler extends AbstractAttachmentHandler {
-
-    public final static int THUMBNAIL_MAX_HEIGHT = 200;
-
-    public final static int THUMBNAIL_MAX_WIDTH = THUMBNAIL_MAX_HEIGHT;
-
-    public ImageAttachmentHandler() {
-        super();
-    }
-
-    @Override
-    protected void setParentComplexObsHandler() {
-        setParent(new ImageHandler());
-    }
-
-    @Override
-    protected ComplexData readComplexData(Obs obs, ValueComplex valueComplex, String view) {
-
-        String fileName = valueComplex.getFileName();
-        if (view.equals(AttachmentsConstants.ATT_VIEW_THUMBNAIL)
-                && !StringUtils.endsWith(FilenameUtils.removeExtension(fileName), NO_THUMBNAIL_SUFFIX)) {
-            fileName = buildThumbnailFileName(fileName);
-        }
-
-        // We invoke the parent to inherit from the file reading routines.
-        Obs tmpObs = new Obs();
-        tmpObs.setValueComplex(fileName); // Temp obs used as a safety
-        tmpObs = getParent().getObs(tmpObs, AttachmentsConstants.IMAGE_HANDLER_VIEW); // ImageHandler doesn't handle several views
-        ComplexData complexData = tmpObs.getComplexData();
-
-        // Then we build our own custom complex data
-        return getComplexDataHelper().build(valueComplex.getInstructions(), complexData.getTitle(), complexData.getData(),
-                valueComplex.getMimeType()).asComplexData();
-    }
-
-    @Override
-    protected boolean deleteComplexData(Obs obs, AttachmentComplexData complexData) {
-
-        // We use a temp obs whose complex data points to the file names
-        String fileName = complexData.getTitle();
-        boolean isThumbNailPurged = true;
-        Obs tmpObs = new Obs();
-
-        if (!StringUtils.endsWith(FilenameUtils.removeExtension(fileName), NO_THUMBNAIL_SUFFIX)) {
-            String thumbnailFileName = buildThumbnailFileName(fileName);
-            tmpObs.setValueComplex(thumbnailFileName);
-            isThumbNailPurged = getParent().purgeComplexData(tmpObs);
-        }
-
-        tmpObs.setValueComplex(fileName);
-        boolean isImagePurged = getParent().purgeComplexData(tmpObs);
-
-        return isThumbNailPurged && isImagePurged;
-    }
-
-    @Override
-    protected ValueComplex saveComplexData(Obs obs, AttachmentComplexData complexData) {
-        int imageHeight = Integer.MAX_VALUE;
-        int imageWidth = Integer.MAX_VALUE;
-        String savedFileName = null;
-
-        // We invoke the parent to inherit from the file saving routines.
-        obs = getParent().saveObs(obs);
-
-        File savedFile = AbstractHandler.getComplexDataFile(obs);
-
-        // Get image dimensions
-        try {
-            BufferedImage image = ImageIO.read(savedFile);
-            imageHeight = image.getHeight();
-            imageWidth = image.getWidth();
-        } catch (IOException e) {
-            log.warn("The dimensions of image 'savedFileName' could not be determined, continuing with generating thumbnail.");
-        }
-
-        try {
-            savedFileName = saveThumbnailOrRename(savedFile, imageHeight, imageWidth);
-        } catch (APIException e) {
-            getParent().purgeComplexData(obs);
-            throw new APIException("A thumbnail file could not be saved for obs with"
-                    + "OBS_ID='" + obs.getObsId() + "', "
-                    + "FILE='" + complexData.getTitle() + "'.", e);
-        }
-
-        return new ValueComplex(complexData.getInstructions(), complexData.getMimeType(), savedFileName);
-    }
+	
+	public final static int THUMBNAIL_MAX_HEIGHT = 200;
+	
+	public final static int THUMBNAIL_MAX_WIDTH = THUMBNAIL_MAX_HEIGHT;
+	
+	public ImageAttachmentHandler() {
+		super();
+	}
+	
+	@Override
+	protected void setParentComplexObsHandler() {
+		setParent(new ImageHandler());
+	}
+	
+	@Override
+	protected ComplexData readComplexData(Obs obs, ValueComplex valueComplex, String view) {
+		
+		String fileName = valueComplex.getFileName();
+		if (view.equals(AttachmentsConstants.ATT_VIEW_THUMBNAIL)
+		        && !StringUtils.endsWith(FilenameUtils.removeExtension(fileName), NO_THUMBNAIL_SUFFIX)) {
+			fileName = buildThumbnailFileName(fileName);
+		}
+		
+		// We invoke the parent to inherit from the file reading routines.
+		Obs tmpObs = new Obs();
+		tmpObs.setValueComplex(fileName); // Temp obs used as a safety
+		tmpObs = getParent().getObs(tmpObs, AttachmentsConstants.IMAGE_HANDLER_VIEW); // ImageHandler doesn't handle
+		                                                                              // several views
+		ComplexData complexData = tmpObs.getComplexData();
+		
+		// Then we build our own custom complex data
+		return getComplexDataHelper().build(valueComplex.getInstructions(), complexData.getTitle(), complexData.getData(),
+		    valueComplex.getMimeType()).asComplexData();
+	}
+	
+	@Override
+	protected boolean deleteComplexData(Obs obs, AttachmentComplexData complexData) {
+		
+		// We use a temp obs whose complex data points to the file names
+		String fileName = complexData.getTitle();
+		boolean isThumbNailPurged = true;
+		Obs tmpObs = new Obs();
+		
+		if (!StringUtils.endsWith(FilenameUtils.removeExtension(fileName), NO_THUMBNAIL_SUFFIX)) {
+			String thumbnailFileName = buildThumbnailFileName(fileName);
+			tmpObs.setValueComplex(thumbnailFileName);
+			isThumbNailPurged = getParent().purgeComplexData(tmpObs);
+		}
+		
+		tmpObs.setValueComplex(fileName);
+		boolean isImagePurged = getParent().purgeComplexData(tmpObs);
+		
+		return isThumbNailPurged && isImagePurged;
+	}
+	
+	@Override
+	protected ValueComplex saveComplexData(Obs obs, AttachmentComplexData complexData) {
+		int imageHeight = Integer.MAX_VALUE;
+		int imageWidth = Integer.MAX_VALUE;
+		String savedFileName = null;
+		
+		// We invoke the parent to inherit from the file saving routines.
+		obs = getParent().saveObs(obs);
+		
+		File savedFile = AbstractHandler.getComplexDataFile(obs);
+		
+		// Get image dimensions
+		try {
+			BufferedImage image = ImageIO.read(savedFile);
+			imageHeight = image.getHeight();
+			imageWidth = image.getWidth();
+		}
+		catch (IOException e) {
+			log.warn(
+			    "The dimensions of image 'savedFileName' could not be determined, continuing with generating thumbnail.");
+		}
+		
+		try {
+			savedFileName = saveThumbnailOrRename(savedFile, imageHeight, imageWidth);
+		}
+		catch (APIException e) {
+			getParent().purgeComplexData(obs);
+			throw new APIException("A thumbnail file could not be saved for obs with" + "OBS_ID='" + obs.getObsId() + "', "
+			        + "FILE='" + complexData.getTitle() + "'.", e);
+		}
+		
+		return new ValueComplex(complexData.getInstructions(), complexData.getMimeType(), savedFileName);
+	}
 }

--- a/api/src/main/java/org/openmrs/module/attachments/obs/ImageAttachmentHandler.java
+++ b/api/src/main/java/org/openmrs/module/attachments/obs/ImageAttachmentHandler.java
@@ -32,8 +32,7 @@ public class ImageAttachmentHandler extends AbstractAttachmentHandler {
 	protected ComplexData readComplexData(Obs obs, ValueComplex valueComplex, String view) {
 		
 		String fileName = valueComplex.getFileName();
-		if (view.equals(AttachmentsConstants.ATT_VIEW_THUMBNAIL)
-		        && !StringUtils.endsWith(FilenameUtils.removeExtension(fileName), NO_THUMBNAIL_SUFFIX)) {
+		if (view.equals(AttachmentsConstants.ATT_VIEW_THUMBNAIL) && !isThumbnail(fileName)) {
 			fileName = buildThumbnailFileName(fileName);
 		}
 		
@@ -41,7 +40,7 @@ public class ImageAttachmentHandler extends AbstractAttachmentHandler {
 		Obs tmpObs = new Obs();
 		tmpObs.setValueComplex(fileName); // Temp obs used as a safety
 		tmpObs = getParent().getObs(tmpObs, AttachmentsConstants.IMAGE_HANDLER_VIEW); // ImageHandler doesn't handle
-		                                                                              // several views
+		// several views
 		ComplexData complexData = tmpObs.getComplexData();
 		
 		// Then we build our own custom complex data
@@ -57,7 +56,7 @@ public class ImageAttachmentHandler extends AbstractAttachmentHandler {
 		boolean isThumbNailPurged = true;
 		Obs tmpObs = new Obs();
 		
-		if (!StringUtils.endsWith(FilenameUtils.removeExtension(fileName), NO_THUMBNAIL_SUFFIX)) {
+		if (!isThumbnail(fileName)) {
 			String thumbnailFileName = buildThumbnailFileName(fileName);
 			tmpObs.setValueComplex(thumbnailFileName);
 			isThumbNailPurged = getParent().purgeComplexData(tmpObs);
@@ -73,12 +72,12 @@ public class ImageAttachmentHandler extends AbstractAttachmentHandler {
 	protected ValueComplex saveComplexData(Obs obs, AttachmentComplexData complexData) {
 		int imageHeight = Integer.MAX_VALUE;
 		int imageWidth = Integer.MAX_VALUE;
-		String savedFileName = null;
 		
 		// We invoke the parent to inherit from the file saving routines.
 		obs = getParent().saveObs(obs);
 		
 		File savedFile = AbstractHandler.getComplexDataFile(obs);
+		String savedFileName = savedFile.getName();
 		
 		// Get image dimensions
 		try {
@@ -87,8 +86,8 @@ public class ImageAttachmentHandler extends AbstractAttachmentHandler {
 			imageWidth = image.getWidth();
 		}
 		catch (IOException e) {
-			log.warn(
-			    "The dimensions of image 'savedFileName' could not be determined, continuing with generating thumbnail.");
+			log.warn("The dimensions of image file '" + savedFileName
+			        + "' could not be determined, continuing with generating its thumbnail anyway.");
 		}
 		
 		try {

--- a/api/src/test/java/org/openmrs/module/attachments/obs/ImageAttachmentHandlerIT.java
+++ b/api/src/test/java/org/openmrs/module/attachments/obs/ImageAttachmentHandlerIT.java
@@ -42,10 +42,9 @@ public class ImageAttachmentHandlerIT extends BaseModuleContextSensitiveTest {
 		BufferedImage img = ImageIO.read(thumbnail);
 		Assert.assertEquals(ImageAttachmentHandler.THUMBNAIL_MAX_HEIGHT, Math.max(img.getHeight(), img.getWidth()));
 		
-		// Now check rename the file by appending NO_THUMBNAIL_SUFFIX to the file
-		String fileName = ImageAttachmentHandler.saveThumbnailOrRename(file, img.getHeight(), img.getWidth());
-		Assert.assertTrue(
-		    StringUtils.endsWith(FilenameUtils.removeExtension(fileName), ImageAttachmentHandler.NO_THUMBNAIL_SUFFIX));
+		File noThumbnailFile = new File(testHelper.getComplexObsDir() + "/"
+		        + ImageAttachmentHandler.buildNoThumbnailFileFileName(mpFile.getOriginalFilename()));
+		Assert.assertFalse(noThumbnailFile.exists());
 	}
 	
 	@Test
@@ -112,8 +111,7 @@ public class ImageAttachmentHandlerIT extends BaseModuleContextSensitiveTest {
 		Assert.assertTrue(ImageAttachmentHandler.THUMBNAIL_MAX_HEIGHT >= Math.max(img.getHeight(), img.getWidth()));
 		
 		// Check that the file name contains the no thumbnail suffix
-		Assert.assertTrue(StringUtils.endsWith(FilenameUtils.removeExtension(noThumbnailFile.getName()),
-		    ImageAttachmentHandler.NO_THUMBNAIL_SUFFIX));
+		Assert.assertTrue(ImageAttachmentHandler.isThumbnail(FilenameUtils.removeExtension(noThumbnailFile.getName())));
 	}
 	
 	@Test

--- a/api/src/test/java/org/openmrs/module/attachments/obs/ImageAttachmentHandlerIT.java
+++ b/api/src/test/java/org/openmrs/module/attachments/obs/ImageAttachmentHandlerIT.java
@@ -7,7 +7,9 @@ import java.io.File;
 import java.io.IOException;
 
 import javax.imageio.ImageIO;
+import org.apache.commons.io.FilenameUtils;
 
+import org.apache.commons.lang.StringUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.openmrs.Obs;
@@ -18,81 +20,133 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockMultipartFile;
 
 public class ImageAttachmentHandlerIT extends BaseModuleContextSensitiveTest {
-	
-	@Autowired
-	protected TestHelper testHelper;
-	
-	@Test
-	public void saveComplexData_shouldSaveThumbnailToDisk() throws IOException {
-		
-		// Replay
-		Obs obs = testHelper.saveNormalSizeImageAttachment();
-		
-		// Verif
-		MockMultipartFile mpFile = testHelper.getLastSavedTestImageFile();
-		File file = new File(testHelper.getComplexObsDir() + "/" + mpFile.getOriginalFilename());
-		Assert.assertTrue(file.exists());
+
+    @Autowired
+    protected TestHelper testHelper;
+
+    @Test
+    public void saveComplexData_shouldSaveThumbnailToDisk() throws IOException {
+
+        // Replay
+        Obs obs = testHelper.saveNormalSizeImageAttachment();
+
+        // Verif
+        MockMultipartFile mpFile = testHelper.getLastSavedTestImageFile();
+        File file = new File(testHelper.getComplexObsDir() + "/" + mpFile.getOriginalFilename());
+        Assert.assertTrue(file.exists());
 		File thumbnail = new File(testHelper.getComplexObsDir() + "/"
 		        + ImageAttachmentHandler.buildThumbnailFileName(mpFile.getOriginalFilename()));
-		Assert.assertTrue(thumbnail.exists());
-		
-		Assert.assertThat(thumbnail.length(), lessThan(file.length()));
-		BufferedImage img = ImageIO.read(thumbnail);
-		Assert.assertEquals(ImageAttachmentHandler.THUMBNAIL_MAX_HEIGHT, Math.max(img.getHeight(), img.getWidth()));
-	}
-	
-	@Test
-	public void deleteComplexData_shouldDeleteThumbnailFromDisk() throws IOException {
-		
-		// Setup
-		Obs obs = testHelper.saveNormalSizeImageAttachment();
-		MockMultipartFile mpFile = testHelper.getLastSavedTestImageFile();
-		
-		// Replay
-		obs = Context.getObsService().getComplexObs(obs.getId(), AttachmentsConstants.ATT_VIEW_CRUD);
-		Context.getObsService().purgeObs(obs);
-		
-		// Verif
-		File file = new File(testHelper.getComplexObsDir() + "/" + mpFile.getOriginalFilename());
-		Assert.assertFalse(file.exists());
+        Assert.assertTrue(thumbnail.exists());
+
+        Assert.assertThat(thumbnail.length(), lessThan(file.length()));
+        BufferedImage img = ImageIO.read(thumbnail);
+        Assert.assertEquals(ImageAttachmentHandler.THUMBNAIL_MAX_HEIGHT, Math.max(img.getHeight(), img.getWidth()));
+
+        // Now check rename the file by appending NO_THUMBNAIL_SUFFIX to the file
+        String fileName = ImageAttachmentHandler.saveThumbnailOrRename(file, img.getHeight(), img.getWidth());
+        Assert.assertTrue(StringUtils.endsWith(FilenameUtils.removeExtension(fileName), ImageAttachmentHandler.NO_THUMBNAIL_SUFFIX));
+    }
+
+    @Test
+    public void deleteComplexData_shouldDeleteThumbnailFromDisk() throws IOException {
+
+        // Setup
+        Obs obs = testHelper.saveNormalSizeImageAttachment();
+        MockMultipartFile mpFile = testHelper.getLastSavedTestImageFile();
+
+        // Replay
+        obs = Context.getObsService().getComplexObs(obs.getId(), AttachmentsConstants.ATT_VIEW_CRUD);
+        Context.getObsService().purgeObs(obs);
+
+        // Verif
+        File file = new File(testHelper.getComplexObsDir() + "/" + mpFile.getOriginalFilename());
+        Assert.assertFalse(file.exists());
 		File thumbnail = new File(testHelper.getComplexObsDir() + "/"
 		        + ImageAttachmentHandler.buildThumbnailFileName(mpFile.getOriginalFilename()));
-		Assert.assertFalse(thumbnail.exists());
-	}
-	
-	@Test
-	public void readComplexData_shouldFetchThumbnail() throws IOException {
-		
-		// Setup
-		Obs obs = testHelper.saveNormalSizeImageAttachment();
-		MockMultipartFile mpFile = testHelper.getLastSavedTestImageFile();
+        Assert.assertFalse(thumbnail.exists());
+    }
+
+    @Test
+    public void readComplexData_shouldFetchThumbnail() throws IOException {
+
+        // Setup
+        Obs obs = testHelper.saveNormalSizeImageAttachment();
+        MockMultipartFile mpFile = testHelper.getLastSavedTestImageFile();
 		File thumbnail = new File(testHelper.getComplexObsDir() + "/"
 		        + ImageAttachmentHandler.buildThumbnailFileName(mpFile.getOriginalFilename()));
-		Assert.assertTrue(thumbnail.exists());
-		byte[] expectedBytes = new BaseComplexData(thumbnail.getName(), ImageIO.read(thumbnail)).asByteArray();
-		
-		// Replay
-		obs = Context.getObsService().getComplexObs(obs.getId(), AttachmentsConstants.ATT_VIEW_THUMBNAIL);
-		
-		// Verif
-		Assert.assertArrayEquals(expectedBytes, BaseComplexData.getByteArray(obs.getComplexData()));
-	}
-	
-	@Test
-	public void saveComplexData_shouldNotSaveThumbnailWhenSmallImage() throws IOException {
-		
-		// Setup
-		Obs obs = testHelper.saveSmallSizeImageAttachment();
-		
-		// TODO: complete the unit test
-	}
-	
-	@Test
-	public void readComplexData_shouldAlwaysFetchOriginalImageWhenSmallImage() throws IOException {
-		
-		// Setup
-		Obs obs = testHelper.saveSmallSizeImageAttachment();
-		
-		// TODO: complete the unit test
-	}
+        Assert.assertTrue(thumbnail.exists());
+        byte[] expectedBytes = new BaseComplexData(thumbnail.getName(), ImageIO.read(thumbnail)).asByteArray();
+
+        // Replay
+        obs = Context.getObsService().getComplexObs(obs.getId(), AttachmentsConstants.ATT_VIEW_THUMBNAIL);
+
+        // Verif
+        Assert.assertArrayEquals(expectedBytes, BaseComplexData.getByteArray(obs.getComplexData()));
+    }
+
+    @Test
+    public void saveComplexData_shouldNotSaveThumbnailWhenSmallImage() throws IOException {
+
+        // Setup
+        Obs obs = testHelper.saveSmallSizeImageAttachment();
+        MockMultipartFile mpFile = testHelper.getLastSavedTestImageFile();
+        String originalFileName = mpFile.getOriginalFilename();
+
+        // Verif the buildNotThumbnailFileFileName()
+        File noThumbnailFile = new File(testHelper.getComplexObsDir() + "/" + ImageAttachmentHandler.buildNoThumbnailFileFileName(originalFileName));
+        Assert.assertTrue(noThumbnailFile.exists());
+        // Not create new file name since it contained NO_THUMBNAIL_SUFFIX
+        noThumbnailFile = new File(testHelper.getComplexObsDir() + "/" + ImageAttachmentHandler.buildNoThumbnailFileFileName(noThumbnailFile.getName()));
+        Assert.assertTrue(noThumbnailFile.exists());
+
+        // Verif the thumbnail file was NOT created
+        File thumbnail = new File(testHelper.getComplexObsDir() + "/" + ImageAttachmentHandler.buildThumbnailFileName(originalFileName));
+        Assert.assertFalse(thumbnail.exists());
+
+        //Assert.assertThat(thumbnail.length(), lessThan(file.length()));
+        BufferedImage img = ImageIO.read(noThumbnailFile);
+        Assert.assertTrue(ImageAttachmentHandler.THUMBNAIL_MAX_HEIGHT >= Math.max(img.getHeight(), img.getWidth()));
+
+        // Check that the file name contains the no thumbnail suffix
+        Assert.assertTrue(StringUtils.endsWith(FilenameUtils.removeExtension(noThumbnailFile.getName()), ImageAttachmentHandler.NO_THUMBNAIL_SUFFIX));
+    }
+
+    @Test
+    public void deleteComplexData_shouldDeleteNoThumbnailFromDisk() throws IOException {
+
+        // Setup
+        Obs obs = testHelper.saveSmallSizeImageAttachment();
+        MockMultipartFile mpFile = testHelper.getLastSavedTestImageFile();
+        String originalFileName = mpFile.getOriginalFilename();
+        // Replay
+        obs = Context.getObsService().getComplexObs(obs.getId(), AttachmentsConstants.ATT_VIEW_CRUD);
+        Context.getObsService().purgeObs(obs);
+
+        // Verif
+        File noThumbnailFile = new File(testHelper.getComplexObsDir() + "/" + ImageAttachmentHandler.buildNoThumbnailFileFileName(originalFileName));
+        Assert.assertFalse(noThumbnailFile.exists());
+    }
+
+    @Test
+    public void readComplexData_shouldAlwaysFetchOriginalImageWhenSmallImage() throws IOException {
+
+        // Setup
+        Obs obs = testHelper.saveSmallSizeImageAttachment();
+        MockMultipartFile mpFile = testHelper.getLastSavedTestImageFile();
+        String originalFileName = mpFile.getOriginalFilename();
+        File noThumbnailFile = new File(testHelper.getComplexObsDir() + "/" + ImageAttachmentHandler.buildNoThumbnailFileFileName(originalFileName));
+        Assert.assertTrue(noThumbnailFile.exists());
+        byte[] expectedBytes = new BaseComplexData(noThumbnailFile.getName(), ImageIO.read(noThumbnailFile)).asByteArray();
+
+        // Replay
+        obs = Context.getObsService().getComplexObs(obs.getId(), AttachmentsConstants.ATT_VIEW_THUMBNAIL);
+
+        // Verif
+        Assert.assertArrayEquals(expectedBytes, BaseComplexData.getByteArray(obs.getComplexData()));
+
+        obs = Context.getObsService().getComplexObs(obs.getId(), AttachmentsConstants.ATT_VIEW_ORIGINAL);
+
+        // Verif
+        Assert.assertArrayEquals(expectedBytes, BaseComplexData.getByteArray(obs.getComplexData()));
+    }
 }

--- a/api/src/test/java/org/openmrs/module/attachments/obs/ImageAttachmentHandlerIT.java
+++ b/api/src/test/java/org/openmrs/module/attachments/obs/ImageAttachmentHandlerIT.java
@@ -20,133 +20,140 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockMultipartFile;
 
 public class ImageAttachmentHandlerIT extends BaseModuleContextSensitiveTest {
-
-    @Autowired
-    protected TestHelper testHelper;
-
-    @Test
-    public void saveComplexData_shouldSaveThumbnailToDisk() throws IOException {
-
-        // Replay
-        Obs obs = testHelper.saveNormalSizeImageAttachment();
-
-        // Verif
-        MockMultipartFile mpFile = testHelper.getLastSavedTestImageFile();
-        File file = new File(testHelper.getComplexObsDir() + "/" + mpFile.getOriginalFilename());
-        Assert.assertTrue(file.exists());
+	
+	@Autowired
+	protected TestHelper testHelper;
+	
+	@Test
+	public void saveComplexData_shouldSaveThumbnailToDisk() throws IOException {
+		
+		// Replay
+		Obs obs = testHelper.saveNormalSizeImageAttachment();
+		
+		// Verif
+		MockMultipartFile mpFile = testHelper.getLastSavedTestImageFile();
+		File file = new File(testHelper.getComplexObsDir() + "/" + mpFile.getOriginalFilename());
+		Assert.assertTrue(file.exists());
 		File thumbnail = new File(testHelper.getComplexObsDir() + "/"
 		        + ImageAttachmentHandler.buildThumbnailFileName(mpFile.getOriginalFilename()));
-        Assert.assertTrue(thumbnail.exists());
-
-        Assert.assertThat(thumbnail.length(), lessThan(file.length()));
-        BufferedImage img = ImageIO.read(thumbnail);
-        Assert.assertEquals(ImageAttachmentHandler.THUMBNAIL_MAX_HEIGHT, Math.max(img.getHeight(), img.getWidth()));
-
-        // Now check rename the file by appending NO_THUMBNAIL_SUFFIX to the file
-        String fileName = ImageAttachmentHandler.saveThumbnailOrRename(file, img.getHeight(), img.getWidth());
-        Assert.assertTrue(StringUtils.endsWith(FilenameUtils.removeExtension(fileName), ImageAttachmentHandler.NO_THUMBNAIL_SUFFIX));
-    }
-
-    @Test
-    public void deleteComplexData_shouldDeleteThumbnailFromDisk() throws IOException {
-
-        // Setup
-        Obs obs = testHelper.saveNormalSizeImageAttachment();
-        MockMultipartFile mpFile = testHelper.getLastSavedTestImageFile();
-
-        // Replay
-        obs = Context.getObsService().getComplexObs(obs.getId(), AttachmentsConstants.ATT_VIEW_CRUD);
-        Context.getObsService().purgeObs(obs);
-
-        // Verif
-        File file = new File(testHelper.getComplexObsDir() + "/" + mpFile.getOriginalFilename());
-        Assert.assertFalse(file.exists());
+		Assert.assertTrue(thumbnail.exists());
+		
+		Assert.assertThat(thumbnail.length(), lessThan(file.length()));
+		BufferedImage img = ImageIO.read(thumbnail);
+		Assert.assertEquals(ImageAttachmentHandler.THUMBNAIL_MAX_HEIGHT, Math.max(img.getHeight(), img.getWidth()));
+		
+		// Now check rename the file by appending NO_THUMBNAIL_SUFFIX to the file
+		String fileName = ImageAttachmentHandler.saveThumbnailOrRename(file, img.getHeight(), img.getWidth());
+		Assert.assertTrue(
+		    StringUtils.endsWith(FilenameUtils.removeExtension(fileName), ImageAttachmentHandler.NO_THUMBNAIL_SUFFIX));
+	}
+	
+	@Test
+	public void deleteComplexData_shouldDeleteThumbnailFromDisk() throws IOException {
+		
+		// Setup
+		Obs obs = testHelper.saveNormalSizeImageAttachment();
+		MockMultipartFile mpFile = testHelper.getLastSavedTestImageFile();
+		
+		// Replay
+		obs = Context.getObsService().getComplexObs(obs.getId(), AttachmentsConstants.ATT_VIEW_CRUD);
+		Context.getObsService().purgeObs(obs);
+		
+		// Verif
+		File file = new File(testHelper.getComplexObsDir() + "/" + mpFile.getOriginalFilename());
+		Assert.assertFalse(file.exists());
 		File thumbnail = new File(testHelper.getComplexObsDir() + "/"
 		        + ImageAttachmentHandler.buildThumbnailFileName(mpFile.getOriginalFilename()));
-        Assert.assertFalse(thumbnail.exists());
-    }
-
-    @Test
-    public void readComplexData_shouldFetchThumbnail() throws IOException {
-
-        // Setup
-        Obs obs = testHelper.saveNormalSizeImageAttachment();
-        MockMultipartFile mpFile = testHelper.getLastSavedTestImageFile();
+		Assert.assertFalse(thumbnail.exists());
+	}
+	
+	@Test
+	public void readComplexData_shouldFetchThumbnail() throws IOException {
+		
+		// Setup
+		Obs obs = testHelper.saveNormalSizeImageAttachment();
+		MockMultipartFile mpFile = testHelper.getLastSavedTestImageFile();
 		File thumbnail = new File(testHelper.getComplexObsDir() + "/"
 		        + ImageAttachmentHandler.buildThumbnailFileName(mpFile.getOriginalFilename()));
-        Assert.assertTrue(thumbnail.exists());
-        byte[] expectedBytes = new BaseComplexData(thumbnail.getName(), ImageIO.read(thumbnail)).asByteArray();
-
-        // Replay
-        obs = Context.getObsService().getComplexObs(obs.getId(), AttachmentsConstants.ATT_VIEW_THUMBNAIL);
-
-        // Verif
-        Assert.assertArrayEquals(expectedBytes, BaseComplexData.getByteArray(obs.getComplexData()));
-    }
-
-    @Test
-    public void saveComplexData_shouldNotSaveThumbnailWhenSmallImage() throws IOException {
-
-        // Setup
-        Obs obs = testHelper.saveSmallSizeImageAttachment();
-        MockMultipartFile mpFile = testHelper.getLastSavedTestImageFile();
-        String originalFileName = mpFile.getOriginalFilename();
-
-        // Verif the buildNotThumbnailFileFileName()
-        File noThumbnailFile = new File(testHelper.getComplexObsDir() + "/" + ImageAttachmentHandler.buildNoThumbnailFileFileName(originalFileName));
-        Assert.assertTrue(noThumbnailFile.exists());
-        // Not create new file name since it contained NO_THUMBNAIL_SUFFIX
-        noThumbnailFile = new File(testHelper.getComplexObsDir() + "/" + ImageAttachmentHandler.buildNoThumbnailFileFileName(noThumbnailFile.getName()));
-        Assert.assertTrue(noThumbnailFile.exists());
-
-        // Verif the thumbnail file was NOT created
-        File thumbnail = new File(testHelper.getComplexObsDir() + "/" + ImageAttachmentHandler.buildThumbnailFileName(originalFileName));
-        Assert.assertFalse(thumbnail.exists());
-
-        //Assert.assertThat(thumbnail.length(), lessThan(file.length()));
-        BufferedImage img = ImageIO.read(noThumbnailFile);
-        Assert.assertTrue(ImageAttachmentHandler.THUMBNAIL_MAX_HEIGHT >= Math.max(img.getHeight(), img.getWidth()));
-
-        // Check that the file name contains the no thumbnail suffix
-        Assert.assertTrue(StringUtils.endsWith(FilenameUtils.removeExtension(noThumbnailFile.getName()), ImageAttachmentHandler.NO_THUMBNAIL_SUFFIX));
-    }
-
-    @Test
-    public void deleteComplexData_shouldDeleteNoThumbnailFromDisk() throws IOException {
-
-        // Setup
-        Obs obs = testHelper.saveSmallSizeImageAttachment();
-        MockMultipartFile mpFile = testHelper.getLastSavedTestImageFile();
-        String originalFileName = mpFile.getOriginalFilename();
-        // Replay
-        obs = Context.getObsService().getComplexObs(obs.getId(), AttachmentsConstants.ATT_VIEW_CRUD);
-        Context.getObsService().purgeObs(obs);
-
-        // Verif
-        File noThumbnailFile = new File(testHelper.getComplexObsDir() + "/" + ImageAttachmentHandler.buildNoThumbnailFileFileName(originalFileName));
-        Assert.assertFalse(noThumbnailFile.exists());
-    }
-
-    @Test
-    public void readComplexData_shouldAlwaysFetchOriginalImageWhenSmallImage() throws IOException {
-
-        // Setup
-        Obs obs = testHelper.saveSmallSizeImageAttachment();
-        MockMultipartFile mpFile = testHelper.getLastSavedTestImageFile();
-        String originalFileName = mpFile.getOriginalFilename();
-        File noThumbnailFile = new File(testHelper.getComplexObsDir() + "/" + ImageAttachmentHandler.buildNoThumbnailFileFileName(originalFileName));
-        Assert.assertTrue(noThumbnailFile.exists());
-        byte[] expectedBytes = new BaseComplexData(noThumbnailFile.getName(), ImageIO.read(noThumbnailFile)).asByteArray();
-
-        // Replay
-        obs = Context.getObsService().getComplexObs(obs.getId(), AttachmentsConstants.ATT_VIEW_THUMBNAIL);
-
-        // Verif
-        Assert.assertArrayEquals(expectedBytes, BaseComplexData.getByteArray(obs.getComplexData()));
-
-        obs = Context.getObsService().getComplexObs(obs.getId(), AttachmentsConstants.ATT_VIEW_ORIGINAL);
-
-        // Verif
-        Assert.assertArrayEquals(expectedBytes, BaseComplexData.getByteArray(obs.getComplexData()));
-    }
+		Assert.assertTrue(thumbnail.exists());
+		byte[] expectedBytes = new BaseComplexData(thumbnail.getName(), ImageIO.read(thumbnail)).asByteArray();
+		
+		// Replay
+		obs = Context.getObsService().getComplexObs(obs.getId(), AttachmentsConstants.ATT_VIEW_THUMBNAIL);
+		
+		// Verif
+		Assert.assertArrayEquals(expectedBytes, BaseComplexData.getByteArray(obs.getComplexData()));
+	}
+	
+	@Test
+	public void saveComplexData_shouldNotSaveThumbnailWhenSmallImage() throws IOException {
+		
+		// Setup
+		Obs obs = testHelper.saveSmallSizeImageAttachment();
+		MockMultipartFile mpFile = testHelper.getLastSavedTestImageFile();
+		String originalFileName = mpFile.getOriginalFilename();
+		
+		// Verif the buildNotThumbnailFileFileName()
+		File noThumbnailFile = new File(
+		        testHelper.getComplexObsDir() + "/" + ImageAttachmentHandler.buildNoThumbnailFileFileName(originalFileName));
+		Assert.assertTrue(noThumbnailFile.exists());
+		// Not create new file name since it contained NO_THUMBNAIL_SUFFIX
+		noThumbnailFile = new File(testHelper.getComplexObsDir() + "/"
+		        + ImageAttachmentHandler.buildNoThumbnailFileFileName(noThumbnailFile.getName()));
+		Assert.assertTrue(noThumbnailFile.exists());
+		
+		// Verif the thumbnail file was NOT created
+		File thumbnail = new File(
+		        testHelper.getComplexObsDir() + "/" + ImageAttachmentHandler.buildThumbnailFileName(originalFileName));
+		Assert.assertFalse(thumbnail.exists());
+		
+		// Assert.assertThat(thumbnail.length(), lessThan(file.length()));
+		BufferedImage img = ImageIO.read(noThumbnailFile);
+		Assert.assertTrue(ImageAttachmentHandler.THUMBNAIL_MAX_HEIGHT >= Math.max(img.getHeight(), img.getWidth()));
+		
+		// Check that the file name contains the no thumbnail suffix
+		Assert.assertTrue(StringUtils.endsWith(FilenameUtils.removeExtension(noThumbnailFile.getName()),
+		    ImageAttachmentHandler.NO_THUMBNAIL_SUFFIX));
+	}
+	
+	@Test
+	public void deleteComplexData_shouldDeleteNoThumbnailFromDisk() throws IOException {
+		
+		// Setup
+		Obs obs = testHelper.saveSmallSizeImageAttachment();
+		MockMultipartFile mpFile = testHelper.getLastSavedTestImageFile();
+		String originalFileName = mpFile.getOriginalFilename();
+		// Replay
+		obs = Context.getObsService().getComplexObs(obs.getId(), AttachmentsConstants.ATT_VIEW_CRUD);
+		Context.getObsService().purgeObs(obs);
+		
+		// Verif
+		File noThumbnailFile = new File(
+		        testHelper.getComplexObsDir() + "/" + ImageAttachmentHandler.buildNoThumbnailFileFileName(originalFileName));
+		Assert.assertFalse(noThumbnailFile.exists());
+	}
+	
+	@Test
+	public void readComplexData_shouldAlwaysFetchOriginalImageWhenSmallImage() throws IOException {
+		
+		// Setup
+		Obs obs = testHelper.saveSmallSizeImageAttachment();
+		MockMultipartFile mpFile = testHelper.getLastSavedTestImageFile();
+		String originalFileName = mpFile.getOriginalFilename();
+		File noThumbnailFile = new File(
+		        testHelper.getComplexObsDir() + "/" + ImageAttachmentHandler.buildNoThumbnailFileFileName(originalFileName));
+		Assert.assertTrue(noThumbnailFile.exists());
+		byte[] expectedBytes = new BaseComplexData(noThumbnailFile.getName(), ImageIO.read(noThumbnailFile)).asByteArray();
+		
+		// Replay
+		obs = Context.getObsService().getComplexObs(obs.getId(), AttachmentsConstants.ATT_VIEW_THUMBNAIL);
+		
+		// Verif
+		Assert.assertArrayEquals(expectedBytes, BaseComplexData.getByteArray(obs.getComplexData()));
+		
+		obs = Context.getObsService().getComplexObs(obs.getId(), AttachmentsConstants.ATT_VIEW_ORIGINAL);
+		
+		// Verif
+		Assert.assertArrayEquals(expectedBytes, BaseComplexData.getByteArray(obs.getComplexData()));
+	}
 }


### PR DESCRIPTION
    The original image dimensions should be checked
    before jumping into creating its thumbnail. If
    the image is small enough to be its own thumbnail
    already, then the same file should be used for both.