### PR TITLE
ATT-32, do not attach to active visit when no encounter is specified

### DIFF
--- a/omod-1.10/src/main/java/org/openmrs/module/attachments/rest/ObsByConceptListSearchHandler1_10.java
+++ b/omod-1.10/src/main/java/org/openmrs/module/attachments/rest/ObsByConceptListSearchHandler1_10.java
@@ -46,7 +46,7 @@ public class ObsByConceptListSearchHandler1_10 implements SearchHandler {
 	protected AttachmentsContext context;
 	
 	private final SearchConfig searchConfig = new SearchConfig("obsByConceptList", RestConstants.VERSION_1 + "/obs",
-	        Arrays.asList("1.10.*", "1.11.*", "1.12.*", "2.0.*"),
+	        Arrays.asList("1.10.*", "1.11.*", "1.12.*", "2.0.*", "2.1.*"),
 	        Arrays.asList(
 	            new SearchQuery.Builder("Allows you to retrieve Observations for a patient and a for list of concepts")
 	                    .withRequiredParameters("patient", "conceptList").build()));

--- a/omod/src/main/java/org/openmrs/module/attachments/web/controller/AttachmentsController.java
+++ b/omod/src/main/java/org/openmrs/module/attachments/web/controller/AttachmentsController.java
@@ -77,6 +77,10 @@ public class AttachmentsController {
 				Encounter encounter = null;
 				if (context.associateWithVisitAndEncounter()) {
 					encounter = context.getAttachmentEncounter(patient, visit, provider);
+				} else {
+					// if there is no default encounter type configured, then do not attach this
+					// attachment to any visit
+					visit = null;
 				}
 				
 				if (StringUtils.isEmpty(instructions))


### PR DESCRIPTION
Hi @mseaton, here is the PR to fix this bug. We should also open a separate ticket for configuring the module to work in both modes, visit-less and automatically attach to current visit?