### PR TITLE
ATT-33 fix by falling back to RAW_VIEW as default

### DIFF
--- a/omod/src/main/java/org/openmrs/module/attachments/web/controller/AttachmentsController.java
+++ b/omod/src/main/java/org/openmrs/module/attachments/web/controller/AttachmentsController.java
@@ -1,13 +1,20 @@
 package org.openmrs.module.attachments.web.controller;
 
+import static org.openmrs.module.attachments.AttachmentsContext.getContentFamily;
+
+import java.io.IOException;
+import java.util.Iterator;
+
+import javax.servlet.http.HttpServletResponse;
+
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.openmrs.Encounter;
 import org.openmrs.Obs;
 import org.openmrs.Patient;
 import org.openmrs.Provider;
 import org.openmrs.Visit;
-import org.openmrs.Encounter;
 import org.openmrs.module.attachments.AttachmentsConstants;
 import org.openmrs.module.attachments.AttachmentsContext;
 import org.openmrs.module.attachments.ComplexObsSaver;
@@ -27,12 +34,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.multipart.MultipartHttpServletRequest;
-
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.util.Iterator;
-
-import static org.openmrs.module.attachments.AttachmentsContext.getContentFamily;
 
 /*
  * @Deprecated and replaced by
@@ -110,7 +111,14 @@ public class AttachmentsController {
 		
 		// Getting the Core/Platform complex data object
 		Obs obs = context.getObsService().getObsByUuid(obsUuid);
+		
 		Obs complexObs = context.getObsService().getComplexObs(obs.getObsId(), view);
+		
+		// fall back to raw view
+		if (complexObs == null) {
+			complexObs = context.getObsService().getComplexObs(obs.getObsId(), "RAW_VIEW");
+		}
+		
 		ComplexData complexData = complexObs.getComplexData();
 		
 		// Switching to our complex data object


### PR DESCRIPTION
Expected Behavior:
Complex Obs using default complex obs handlers in the GP list function correctly when generating thumbnails and download requested.

Observed Behavior:
Thumbnails and downloads resulted in Attachments NPEs

Fix approach:
The default handlers only return ComplexData for RAW_VIEW. In the case the attachment view is not supported by the handler, fall back to RAW_VIEW.

https://issues.openmrs.org/browse/ATT-33
