### PR TITLE
ATT-33: Support ComplexObs views in both 1.10+ and 2.0+.

### DIFF
--- a/api-2.0/src/main/java/org/openmrs/module/attachments/obs/ComplexViewHelper2_0.java
+++ b/api-2.0/src/main/java/org/openmrs/module/attachments/obs/ComplexViewHelper2_0.java
@@ -12,11 +12,10 @@ public class ComplexViewHelper2_0 implements ComplexViewHelper {
 	
 	@Override
 	public String getView(Obs obs, String view) {
-		// Obs obs will help the 2.x implementation support fetching the
+		// TODO: Obs obs will help the 2.x implementation support fetching the
 		// supported views for that obs,
-		// using for example:
-		// https://github.com/openmrs/openmrs-core/blob/7da5be1bc34fc4928779f303cd48d42b8a3cae0a/api/src/main/java/org/openmrs/api/ObsService.java#L417-L428
-		// and AbstractHandler derived handlers method getSupportedViews()
+		// See:
+		// https://issues.openmrs.org/browse/ATT-34
 		
 		return ComplexObsHandler.RAW_VIEW;
 	}

--- a/api-2.0/src/main/java/org/openmrs/module/attachments/obs/ComplexViewHelper2_0.java
+++ b/api-2.0/src/main/java/org/openmrs/module/attachments/obs/ComplexViewHelper2_0.java
@@ -1,0 +1,18 @@
+package org.openmrs.module.attachments.obs;
+
+import org.openmrs.annotation.OpenmrsProfile;
+import org.openmrs.module.attachments.AttachmentsConstants;
+import org.openmrs.module.attachments.obs.ComplexViewHelper;
+import org.openmrs.obs.ComplexObsHandler;
+import org.springframework.stereotype.Component;
+
+@Component(AttachmentsConstants.COMPONENT_COMPLEXVIEW_HELPER)
+@OpenmrsProfile(openmrsPlatformVersion = "2.0.0")
+public class ComplexViewHelper2_0 implements ComplexViewHelper {
+	
+	@Override
+	public String getView(String view) {
+		
+		return ComplexObsHandler.RAW_VIEW;
+	}
+}

--- a/api-2.0/src/main/java/org/openmrs/module/attachments/obs/ComplexViewHelper2_0.java
+++ b/api-2.0/src/main/java/org/openmrs/module/attachments/obs/ComplexViewHelper2_0.java
@@ -12,6 +12,11 @@ public class ComplexViewHelper2_0 implements ComplexViewHelper {
 	
 	@Override
 	public String getView(Obs obs, String view) {
+		// Obs obs will help the 2.x implementation support fetching the
+		// supported views for that obs,
+		// using for example:
+		// https://github.com/openmrs/openmrs-core/blob/7da5be1bc34fc4928779f303cd48d42b8a3cae0a/api/src/main/java/org/openmrs/api/ObsService.java#L417-L428
+		// and AbstractHandler derived handlers method getSupportedViews()
 		
 		return ComplexObsHandler.RAW_VIEW;
 	}

--- a/api-2.0/src/main/java/org/openmrs/module/attachments/obs/ComplexViewHelper2_0.java
+++ b/api-2.0/src/main/java/org/openmrs/module/attachments/obs/ComplexViewHelper2_0.java
@@ -1,8 +1,8 @@
 package org.openmrs.module.attachments.obs;
 
+import org.openmrs.Obs;
 import org.openmrs.annotation.OpenmrsProfile;
 import org.openmrs.module.attachments.AttachmentsConstants;
-import org.openmrs.module.attachments.obs.ComplexViewHelper;
 import org.openmrs.obs.ComplexObsHandler;
 import org.springframework.stereotype.Component;
 
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 public class ComplexViewHelper2_0 implements ComplexViewHelper {
 	
 	@Override
-	public String getView(String view) {
+	public String getView(Obs obs, String view) {
 		
 		return ComplexObsHandler.RAW_VIEW;
 	}

--- a/api/src/main/java/org/openmrs/module/attachments/AttachmentsConstants.java
+++ b/api/src/main/java/org/openmrs/module/attachments/AttachmentsConstants.java
@@ -51,6 +51,8 @@ public class AttachmentsConstants {
 	
 	public static final String COMPONENT_COMPLEXOBS_SAVER = MODULE_ARTIFACT_ID + ".ComplexObsSaver";
 	
+	public static final String COMPONENT_COMPLEXVIEW_HELPER = MODULE_ARTIFACT_ID + ".ComplexViewHelper";
+	
 	/*
 	 * Concepts (also used in global prop. in config.xml)
 	 */

--- a/api/src/main/java/org/openmrs/module/attachments/AttachmentsContext.java
+++ b/api/src/main/java/org/openmrs/module/attachments/AttachmentsContext.java
@@ -9,6 +9,13 @@
  */
 package org.openmrs.module.attachments;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.apache.commons.lang.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
@@ -35,18 +42,12 @@ import org.openmrs.api.VisitService;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.attachments.AttachmentsConstants.ContentFamily;
 import org.openmrs.module.attachments.obs.ComplexDataHelper;
+import org.openmrs.module.attachments.obs.ComplexViewHelper;
 import org.openmrs.module.emrapi.adt.AdtService;
 import org.openmrs.module.emrapi.utils.ModuleProperties;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 /**
  * Inject this class to access services and global properties.
@@ -71,6 +72,10 @@ public class AttachmentsContext extends ModuleProperties {
 	@Autowired
 	@Qualifier(AttachmentsConstants.COMPONENT_COMPLEXDATA_HELPER)
 	protected ComplexDataHelper complexDataHelper;
+	
+	@Autowired
+	@Qualifier(AttachmentsConstants.COMPONENT_COMPLEXVIEW_HELPER)
+	protected ComplexViewHelper complexViewHelper;
 	
 	@Autowired
 	@Qualifier(AttachmentsConstants.COMPONENT_VISIT_COMPATIBILITY)
@@ -114,6 +119,10 @@ public class AttachmentsContext extends ModuleProperties {
 	
 	public ComplexDataHelper getComplexDataHelper() {
 		return complexDataHelper;
+	}
+	
+	public ComplexViewHelper getComplexViewHelper() {
+		return complexViewHelper;
 	}
 	
 	public AdministrationService getAdministrationService() {

--- a/api/src/main/java/org/openmrs/module/attachments/obs/ComplexViewHelper.java
+++ b/api/src/main/java/org/openmrs/module/attachments/obs/ComplexViewHelper.java
@@ -1,0 +1,15 @@
+package org.openmrs.module.attachments.obs;
+
+/**
+ * The contents of this file are subject to the OpenMRS Public License Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy of the
+ * License at http://license.openmrs.org Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for the
+ * specific language governing rights and limitations under the License. Copyright (C) OpenMRS, LLC.
+ * All Rights Reserved.
+ */
+public interface ComplexViewHelper {
+	
+	public String getView(String view);
+	
+}

--- a/api/src/main/java/org/openmrs/module/attachments/obs/ComplexViewHelper.java
+++ b/api/src/main/java/org/openmrs/module/attachments/obs/ComplexViewHelper.java
@@ -1,5 +1,7 @@
 package org.openmrs.module.attachments.obs;
 
+import org.openmrs.Obs;
+
 /**
  * The contents of this file are subject to the OpenMRS Public License Version 1.0 (the "License");
  * you may not use this file except in compliance with the License. You may obtain a copy of the
@@ -10,6 +12,16 @@ package org.openmrs.module.attachments.obs;
  */
 public interface ComplexViewHelper {
 	
-	public String getView(String view);
+	/**
+	 * This method handles providing a usable/correct view argument to both OpenMRS 1.10+ and 2.0+
+	 * given an OpenMRS 1.10+ view string
+	 * 
+	 * @param obs This will help the 2.x implementation support fetching the supported views for
+	 *            that obs,using for example:
+	 *            https://github.com/openmrs/openmrs-core/blob/7da5be1bc34fc4928779f303cd48d42b8a3cae0a/api/src/main/java/org/openmrs/api/ObsService.java#L417-L428
+	 * @param view the ATT or OpenMRS 1.10+ view string
+	 * @return a corresponding 1.10+ or 2.0+ view string
+	 */
+	public String getView(Obs obs, String view);
 	
 }

--- a/api/src/main/java/org/openmrs/module/attachments/obs/ComplexViewHelper.java
+++ b/api/src/main/java/org/openmrs/module/attachments/obs/ComplexViewHelper.java
@@ -13,11 +13,11 @@ import org.openmrs.Obs;
 public interface ComplexViewHelper {
 	
 	/**
-	 * This method handles providing a usable/correct view argument to both OpenMRS 1.10+ and 2.0+
-	 * given an OpenMRS 1.10+ view string
+	 * This method handles providing a usable/correct view argument to both OpenMRS 1.10+ and 2.0+ given
+	 * an OpenMRS 1.10+ view string
 	 * 
-	 * @param obs This will help the 2.x implementation support fetching the supported views for
-	 *            that obs,using for example:
+	 * @param obs This will help the 2.x implementation support fetching the supported views for that
+	 *            obs,using for example:
 	 *            https://github.com/openmrs/openmrs-core/blob/7da5be1bc34fc4928779f303cd48d42b8a3cae0a/api/src/main/java/org/openmrs/api/ObsService.java#L417-L428
 	 * @param view the ATT or OpenMRS 1.10+ view string
 	 * @return a corresponding 1.10+ or 2.0+ view string

--- a/api/src/main/java/org/openmrs/module/attachments/obs/ComplexViewHelper1_10.java
+++ b/api/src/main/java/org/openmrs/module/attachments/obs/ComplexViewHelper1_10.java
@@ -1,0 +1,16 @@
+package org.openmrs.module.attachments.obs;
+
+import org.openmrs.annotation.OpenmrsProfile;
+import org.openmrs.module.attachments.AttachmentsConstants;
+import org.openmrs.obs.ComplexObsHandler;
+import org.springframework.stereotype.Component;
+
+@Component(AttachmentsConstants.COMPONENT_COMPLEXVIEW_HELPER)
+@OpenmrsProfile(openmrsPlatformVersion = "1.*")
+public class ComplexViewHelper1_10 implements ComplexViewHelper {
+	
+	public String getView(String view) {
+		
+		return view;
+	}
+}

--- a/api/src/main/java/org/openmrs/module/attachments/obs/ComplexViewHelper1_10.java
+++ b/api/src/main/java/org/openmrs/module/attachments/obs/ComplexViewHelper1_10.java
@@ -1,15 +1,15 @@
 package org.openmrs.module.attachments.obs;
 
+import org.openmrs.Obs;
 import org.openmrs.annotation.OpenmrsProfile;
 import org.openmrs.module.attachments.AttachmentsConstants;
-import org.openmrs.obs.ComplexObsHandler;
 import org.springframework.stereotype.Component;
 
 @Component(AttachmentsConstants.COMPONENT_COMPLEXVIEW_HELPER)
 @OpenmrsProfile(openmrsPlatformVersion = "1.*")
 public class ComplexViewHelper1_10 implements ComplexViewHelper {
 	
-	public String getView(String view) {
+	public String getView(Obs obs, String view) {
 		
 		return view;
 	}

--- a/omod-1.10/src/main/java/org/openmrs/module/attachments/rest/AttachmentBytesResource1_10.java
+++ b/omod-1.10/src/main/java/org/openmrs/module/attachments/rest/AttachmentBytesResource1_10.java
@@ -1,5 +1,11 @@
 package org.openmrs.module.attachments.rest;
 
+import static org.openmrs.module.attachments.AttachmentsContext.getContentFamily;
+
+import java.io.IOException;
+
+import javax.servlet.http.HttpServletResponse;
+
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -8,6 +14,7 @@ import org.openmrs.api.context.Context;
 import org.openmrs.module.attachments.AttachmentsConstants;
 import org.openmrs.module.attachments.AttachmentsContext;
 import org.openmrs.module.attachments.obs.AttachmentComplexData;
+import org.openmrs.module.attachments.obs.ComplexViewHelper;
 import org.openmrs.module.attachments.obs.ValueComplex;
 import org.openmrs.module.webservices.rest.web.RestConstants;
 import org.openmrs.module.webservices.rest.web.response.GenericRestException;
@@ -19,11 +26,6 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-
-import static org.openmrs.module.attachments.AttachmentsContext.getContentFamily;
 
 @Controller
 @RequestMapping(value = "/rest/" + RestConstants.VERSION_1 + "/" + AttachmentsConstants.ATTACHMENT_URI)
@@ -44,7 +46,9 @@ public class AttachmentBytesResource1_10 extends BaseRestController {
 			        + "Obs UUID: " + obs.getUuid());
 		}
 		
-		Obs complexObs = Context.getObsService().getComplexObs(obs.getObsId(), null);
+		ComplexViewHelper viewHelper = context.getComplexViewHelper();
+		
+		Obs complexObs = Context.getObsService().getComplexObs(obs.getObsId(), viewHelper.getView(null));
 		ComplexData complexData = complexObs.getComplexData();
 		
 		// Switching to our complex data object

--- a/omod-1.10/src/main/java/org/openmrs/module/attachments/rest/AttachmentBytesResource1_10.java
+++ b/omod-1.10/src/main/java/org/openmrs/module/attachments/rest/AttachmentBytesResource1_10.java
@@ -48,7 +48,7 @@ public class AttachmentBytesResource1_10 extends BaseRestController {
 		
 		ComplexViewHelper viewHelper = context.getComplexViewHelper();
 		
-		Obs complexObs = Context.getObsService().getComplexObs(obs.getObsId(), viewHelper.getView(null));
+		Obs complexObs = Context.getObsService().getComplexObs(obs.getObsId(), viewHelper.getView(obs, null));
 		ComplexData complexData = complexObs.getComplexData();
 		
 		// Switching to our complex data object

--- a/omod-1.10/src/main/java/org/openmrs/module/attachments/rest/AttachmentResource1_10.java
+++ b/omod-1.10/src/main/java/org/openmrs/module/attachments/rest/AttachmentResource1_10.java
@@ -20,6 +20,7 @@ import org.openmrs.module.attachments.AttachmentsContext;
 import org.openmrs.module.attachments.AttachmentsService;
 import org.openmrs.module.attachments.ComplexObsSaver;
 import org.openmrs.module.attachments.obs.Attachment;
+import org.openmrs.module.attachments.obs.ComplexViewHelper;
 import org.openmrs.module.attachments.obs.ValueComplex;
 import org.openmrs.module.webservices.rest.web.ConversionUtil;
 import org.openmrs.module.webservices.rest.web.RequestContext;
@@ -51,6 +52,9 @@ public class AttachmentResource1_10 extends DataDelegatingCrudResource<Attachmen
 	AttachmentsContext attachmentsContext = Context.getRegisteredComponent(AttachmentsConstants.COMPONENT_ATT_CONTEXT,
 	    AttachmentsContext.class);
 	
+	ComplexViewHelper viewHelper = Context.getRegisteredComponent(AttachmentsConstants.COMPONENT_COMPLEXVIEW_HELPER,
+	    ComplexViewHelper.class);
+	
 	@Override
 	public Attachment newDelegate() {
 		return new Attachment();
@@ -68,7 +72,7 @@ public class AttachmentResource1_10 extends DataDelegatingCrudResource<Attachmen
 		if (!obs.isComplex())
 			throw new GenericRestException(uniqueId + " does not identify a complex obs.", null);
 		else {
-			obs = Context.getObsService().getComplexObs(obs.getId(), AttachmentsConstants.ATT_VIEW_CRUD);
+			obs = Context.getObsService().getComplexObs(obs.getId(), viewHelper.getView(AttachmentsConstants.ATT_VIEW_CRUD));
 			return new Attachment(obs);
 		}
 	}
@@ -99,7 +103,7 @@ public class AttachmentResource1_10 extends DataDelegatingCrudResource<Attachmen
 		String instructions = context.getParameter("instructions");
 		
 		// Verify File Size
-		if (attachmentsContext.getMaxUploadFileSize() * 1024 * 1024 < (double) file.getSize()) {
+		if (attachmentsContext.getMaxUploadFileSize() * 1024 * 1024 < file.getSize()) {
 			throw new IllegalRequestException("The file  exceeds the maximum size");
 		}
 		

--- a/omod-1.10/src/main/java/org/openmrs/module/attachments/rest/AttachmentResource1_10.java
+++ b/omod-1.10/src/main/java/org/openmrs/module/attachments/rest/AttachmentResource1_10.java
@@ -72,7 +72,8 @@ public class AttachmentResource1_10 extends DataDelegatingCrudResource<Attachmen
 		if (!obs.isComplex())
 			throw new GenericRestException(uniqueId + " does not identify a complex obs.", null);
 		else {
-			obs = Context.getObsService().getComplexObs(obs.getId(), viewHelper.getView(AttachmentsConstants.ATT_VIEW_CRUD));
+			obs = Context.getObsService().getComplexObs(obs.getId(),
+			    viewHelper.getView(obs, AttachmentsConstants.ATT_VIEW_CRUD));
 			return new Attachment(obs);
 		}
 	}

--- a/omod/src/main/java/org/openmrs/module/attachments/web/controller/AttachmentsController.java
+++ b/omod/src/main/java/org/openmrs/module/attachments/web/controller/AttachmentsController.java
@@ -114,7 +114,7 @@ public class AttachmentsController {
 		
 		// Getting the Core/Platform complex data object
 		Obs obs = context.getObsService().getObsByUuid(obsUuid);
-		Obs complexObs = context.getObsService().getComplexObs(obs.getObsId(), viewHelper.getView(view));
+		Obs complexObs = context.getObsService().getComplexObs(obs.getObsId(), viewHelper.getView(obs, view));
 		ComplexData complexData = complexObs.getComplexData();
 		
 		// Switching to our complex data object

--- a/omod/src/main/java/org/openmrs/module/attachments/web/controller/AttachmentsController.java
+++ b/omod/src/main/java/org/openmrs/module/attachments/web/controller/AttachmentsController.java
@@ -1,18 +1,26 @@
 package org.openmrs.module.attachments.web.controller;
 
+import static org.openmrs.module.attachments.AttachmentsContext.getContentFamily;
+
+import java.io.IOException;
+import java.util.Iterator;
+
+import javax.servlet.http.HttpServletResponse;
+
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.openmrs.Encounter;
 import org.openmrs.Obs;
 import org.openmrs.Patient;
 import org.openmrs.Provider;
 import org.openmrs.Visit;
-import org.openmrs.Encounter;
 import org.openmrs.module.attachments.AttachmentsConstants;
 import org.openmrs.module.attachments.AttachmentsContext;
 import org.openmrs.module.attachments.ComplexObsSaver;
 import org.openmrs.module.attachments.VisitCompatibility;
 import org.openmrs.module.attachments.obs.AttachmentComplexData;
+import org.openmrs.module.attachments.obs.ComplexViewHelper;
 import org.openmrs.module.attachments.obs.ValueComplex;
 import org.openmrs.module.attachments.rest.AttachmentBytesResource1_10;
 import org.openmrs.module.webservices.rest.web.ConversionUtil;
@@ -27,12 +35,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.multipart.MultipartHttpServletRequest;
-
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.util.Iterator;
-
-import static org.openmrs.module.attachments.AttachmentsContext.getContentFamily;
 
 /*
  * @Deprecated and replaced by
@@ -108,9 +110,11 @@ public class AttachmentsController {
 		if (StringUtils.isEmpty(view))
 			view = AttachmentsConstants.ATT_VIEW_ORIGINAL;
 		
+		ComplexViewHelper viewHelper = context.getComplexViewHelper();
+		
 		// Getting the Core/Platform complex data object
 		Obs obs = context.getObsService().getObsByUuid(obsUuid);
-		Obs complexObs = context.getObsService().getComplexObs(obs.getObsId(), view);
+		Obs complexObs = context.getObsService().getComplexObs(obs.getObsId(), viewHelper.getView(view));
 		ComplexData complexData = complexObs.getComplexData();
 		
 		// Switching to our complex data object


### PR DESCRIPTION
JIRA Ticket: https://issues.openmrs.org/browse/ATT-33

Expected:
Using default complex obs handlers in 2.0 like BinaryDataHandler will successfully provide thumbnails and allow download

Observed:
Default complex obs handlers crash with an NPE on [these lines](https://github.com/openmrs/openmrs-module-attachments/blob/f77901d1b5977573f5c46554d526a0a36f98753e/omod/src/main/java/org/openmrs/module/attachments/web/controller/AttachmentsController.java#L113-L114) because 2.x returns null when the view is not supported (only RAW_VIEW is supported by default).

e.g.
https://github.com/openmrs/openmrs-core/blob/8b870c34732a9c5ba4f312877eab1f8222b5ad48/api/src/main/java/org/openmrs/obs/handler/BinaryDataHandler.java#L60-L77

How it was addressed:

Implemented using simple ComplexViewHelper per OpenMRS core version, 1.10 and 2.0 (patterned after ComplexDataHelper)

1.10 code path verified in unit tests
2.0 code path also verified manually with running distro