### PR TITLE
ATT-40: Visit Actions required privilege updated.

### DIFF
--- a/omod/src/main/resources/apps/visitActions_extension.json
+++ b/omod/src/main/resources/apps/visitActions_extension.json
@@ -7,6 +7,6 @@
         "url" : "attachments/attachments.page?patient={{patient.uuid}}&patientId={{patient.patientId}}&visit={{visit.uuid}}",
         "icon" : "icon-paper-clip",
         "order" : 200,
-        "requiredPrivilege" : "attachments.attachments.page"
+        "requiredPrivilege" : "App: ${project.parent.artifactId}.attachments.page"
     }
 ]


### PR DESCRIPTION
Privilege required for showing link for `attachments` in visit actions updated