### PR TITLE
RA-452: Download rather than render html attachments

### DIFF
--- a/omod/src/main/java/org/openmrs/module/attachments/web/controller/AttachmentsController.java
+++ b/omod/src/main/java/org/openmrs/module/attachments/web/controller/AttachmentsController.java
@@ -131,6 +131,7 @@ public class AttachmentsController {
 			response.addHeader("Content-Family", getContentFamily(mimeType).name()); // custom header
 			response.addHeader("File-Name", docComplexData.getTitle()); // custom header
 			response.addHeader("File-Ext", AttachmentBytesResource1_10.getExtension(docComplexData.getTitle(), mimeType)); // custom header
+			response.addHeader("Content-Disposition", "attachment");
 			switch (getContentFamily(mimeType)) {
 				default:
 					response.getOutputStream().write(docComplexData.asByteArray());


### PR DESCRIPTION
**Why?**
Patch xss bug reported by David Lindner. See: https://talk.openmrs.org/t/openmrs-critical-security-vulnerability/28311

**What Changed?**
Added the `Content-Disposition` header to download responses. This indicates to browsers that the download should not immediately be rendered by the browser, thus preventing automatic execution of any scripts in HTML downloads. See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition

**Decisions Made**
Decided to use the `Content-Disposition` header rather than filtering based on content or file extension because the latter approach is difficult to implement effectively and has more of a potential to break existing workflows.