### PR TITLE
ATT-48: Complex Obs Encounter Template to handle time zones conversions.

### DIFF
--- a/omod/src/main/webapp/fragments/complexObsEncounterTemplate.gsp
+++ b/omod/src/main/webapp/fragments/complexObsEncounterTemplate.gsp
@@ -71,7 +71,7 @@
 
   <script type="text/template" id="complexObsEncounterTemplate">
   <li>
-    <div class="encounter-date ${ui.handleTimeZones() ? 'rfc3339-date' : ''}">
+    <div class="encounter-date ${ui.convertTimezones() ? 'rfc3339-date' : ''}">
       <i class="icon-time"></i>
       <strong class="encounter-time">
         {{- encounter.encounterTime }}

--- a/omod/src/main/webapp/fragments/complexObsEncounterTemplate.gsp
+++ b/omod/src/main/webapp/fragments/complexObsEncounterTemplate.gsp
@@ -71,12 +71,14 @@
 
   <script type="text/template" id="complexObsEncounterTemplate">
   <li>
-    <div class="encounter-date">
+    <div class="encounter-date ${ui.handleTimeZones() ? 'rfc3339-date' : ''}">
       <i class="icon-time"></i>
-      <strong>
+      <strong class="encounter-time">
         {{- encounter.encounterTime }}
       </strong>
-      {{- encounter.encounterDate }}
+      <spann class="encounter-datetime">
+        {{- encounter.encounterDate }}
+      </spann>
     </div>
     <ul class="encounter-details">
       <li> 

--- a/omod/src/main/webapp/fragments/dependenciesFileUpload.gsp
+++ b/omod/src/main/webapp/fragments/dependenciesFileUpload.gsp
@@ -1,7 +1,7 @@
 <%
   ui.includeJavascript("uicommons", "services/obsService.js")
   ui.includeJavascript("uicommons", "services/session.js")
-  ui.includeJavascript("attachments", "date/moment.min.js")
+  ui.includeJavascript("uicommons", "moment-with-locales.min.js")
   ui.includeJavascript("attachments", "dropzone/dropzone.js")
   ui.includeCss("attachments", "dropzone/basic.css")
   ui.includeCss("attachments", "dropzone/dropzone.css")

--- a/omod/src/main/webapp/fragments/dependenciesThumbnail.gsp
+++ b/omod/src/main/webapp/fragments/dependenciesThumbnail.gsp
@@ -8,7 +8,7 @@
   ui.includeCss("uicommons", "ngDialog/ngDialog.min.css")
   ui.includeJavascript("attachments", "directives/modalImage.js")
   ui.includeCss("attachments", "icon.css")
-  ui.includeJavascript("attachments", "date/moment.min.js")
+  ui.includeJavascript("uicommons", "moment-with-locales.min.js")
   ui.includeJavascript("attachments", "image/exif.js")
   ui.includeJavascript("attachments", "image/angular-fix-image-orientation.js")
 %>

--- a/pom.xml
+++ b/pom.xml
@@ -42,8 +42,8 @@
     <openMRSVersion>1.10.5</openMRSVersion>
     <openMRS2_0Version>2.0.0</openMRS2_0Version>
     <appframeworkVersion>2.2.1</appframeworkVersion>
-    <uiframeworkVersion>3.3.1</uiframeworkVersion>
-    <uicommonsVersion>1.4</uicommonsVersion> 
+    <uiframeworkVersion>3.21.0-SNAPSHOT</uiframeworkVersion>
+    <uicommonsVersion>2.16.0</uicommonsVersion>
     <webservices.restVersion>2.17</webservices.restVersion>
     <emrapiVersion>1.19</emrapiVersion>
     <reportingVersion>0.9.2.1</reportingVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <reportingVersion>0.9.2.1</reportingVersion>
     <calculationVersion>1.1</calculationVersion>
     <serialization.xstreamVersion>0.2.8</serialization.xstreamVersion>
-    <providermanagementVersion>2.2</providermanagementVersion>
+    <providermanagementVersion>2.3</providermanagementVersion>
     <appuiVersion>1.3</appuiVersion>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>


### PR DESCRIPTION
#### Ticket:
https://issues.openmrs.org/browse/ATT-48
#### What I have done:
* Upgrade UIFR from 3.3.1 to 3.21.0-SNAPSHOT, to access the new `UiUtils` tz API (see [UIFR-219](https://issues.openmrs.org/browse/UIFR-219)).
* Upgrade UICM 1.4 to 2.16.0, to be able to import its Moment.js with locales.
* Using Moment.js with locales instead of the older Moment.js version that was being used (for example to be able to regionalise months names.)