### PR TITLE
EMPT-41: Prevent upload of executable and script files.

### DIFF
--- a/api/src/main/java/org/openmrs/module/attachments/AttachmentsConstants.java
+++ b/api/src/main/java/org/openmrs/module/attachments/AttachmentsConstants.java
@@ -9,9 +9,13 @@
  */
 package org.openmrs.module.attachments;
 
+import java.util.List;
+import java.util.Arrays;
+
 public class AttachmentsConstants {
 	
 	public static enum ContentFamily {
+		EXECUTABLE,
 		IMAGE,
 		PDF,
 		OTHER
@@ -68,6 +72,12 @@ public class AttachmentsConstants {
 	public static final String INSTRUCTIONS_PREFIX = "instructions";
 	
 	public static final String UNKNOWN_MIME_TYPE = "application/octet-stream";
+	
+	public static final List<String> EXECUTABLE_MIME_TYPES = Arrays.asList("application/vnd.microsoft.portable-executable",
+	    "type/javascript", "application/javascrip", "application/x-sh", "application/java-archive",
+	    "application/x-httpd-php", "application/xhtml+xml", "application/x-vbs", "text/vbscript", "text/x-python",
+	    "application/x-ms-installer", "application/x-elf", "application/x-applescript", "application/x-ruby",
+	    "application/x-perl", "application/wasm");
 	
 	public static final String ATT_VIEW_ORIGINAL = "complexdata.view.original";
 	

--- a/api/src/main/java/org/openmrs/module/attachments/AttachmentsContext.java
+++ b/api/src/main/java/org/openmrs/module/attachments/AttachmentsContext.java
@@ -345,6 +345,10 @@ public class AttachmentsContext extends ModuleProperties {
 	 */
 	public static ContentFamily getContentFamily(String mimeType) {
 		ContentFamily contentFamily = ContentFamily.OTHER;
+		if (AttachmentsConstants.EXECUTABLE_MIME_TYPES.contains(mimeType)) {
+			contentFamily = ContentFamily.EXECUTABLE;
+		}
+		
 		if (StringUtils.equals(mimeType, "application/pdf")) {
 			contentFamily = ContentFamily.PDF;
 		}

--- a/omod-1.10/src/main/java/org/openmrs/module/attachments/rest/AttachmentResource1_10.java
+++ b/omod-1.10/src/main/java/org/openmrs/module/attachments/rest/AttachmentResource1_10.java
@@ -57,8 +57,8 @@ public class AttachmentResource1_10 extends DataDelegatingCrudResource<Attachmen
 	private ComplexObsSaver obsSaver = Context.getRegisteredComponent(AttachmentsConstants.COMPONENT_COMPLEXOBS_SAVER,
 	    ComplexObsSaver.class);
 	
-	private AttachmentsContext ctx = Context
-	        .getRegisteredComponent(AttachmentsConstants.COMPONENT_ATT_CONTEXT, AttachmentsContext.class);
+	private AttachmentsContext ctx = Context.getRegisteredComponent(AttachmentsConstants.COMPONENT_ATT_CONTEXT,
+	    AttachmentsContext.class);
 	
 	@Override
 	public Attachment newDelegate() {
@@ -112,7 +112,7 @@ public class AttachmentResource1_10 extends DataDelegatingCrudResource<Attachmen
 			file = new Base64MultipartFile(base64Content);
 		}
 		// Verify File Size
-		if (ctx.getMaxUploadFileSize() * 1024 * 1024 < (double)file.getSize()) {
+		if (ctx.getMaxUploadFileSize() * 1024 * 1024 < (double) file.getSize()) {
 			throw new IllegalRequestException("The file  exceeds the maximum size");
 		}
 		
@@ -147,6 +147,9 @@ public class AttachmentResource1_10 extends DataDelegatingCrudResource<Attachmen
 				obs = obsSaver.saveImageAttachment(visit, patient, encounter, fileCaption, file, instructions);
 				break;
 			
+			case EXECUTABLE:
+				throw new IllegalRequestException("File type is not allowed as attachment.");
+				
 			case OTHER:
 			default:
 				obs = obsSaver.saveOtherAttachment(visit, patient, encounter, fileCaption, file, instructions);

--- a/omod-1.10/src/test/java/org/openmrs/module/attachments/rest/AttachmentRestController1_10Test.java
+++ b/omod-1.10/src/test/java/org/openmrs/module/attachments/rest/AttachmentRestController1_10Test.java
@@ -439,6 +439,27 @@ public class AttachmentRestController1_10Test extends MainResourceControllerTest
 		SimpleObject response = deserialize(handle(request));
 	}
 	
+	@Test(expected = IllegalRequestException.class)
+	public void postAttachment_shouldThrowOnExecutableFile() throws Exception {
+		// Setup
+		String dotExeMimeType = "application/vnd.microsoft.portable-executable";
+		String fileCaption = "Test file caption";
+		String fileName = "testFile1.dat";
+		Patient patient = Context.getPatientService().getPatient(2);
+		Visit visit = Context.getVisitService().getVisit(1);
+		
+		MockMultipartHttpServletRequest request = newUploadRequest(getURI());
+		MockMultipartFile dotExeFile = new MockMultipartFile("file", fileName, dotExeMimeType, randomData);
+		
+		request.addFile(dotExeFile);
+		request.addParameter("patient", patient.getUuid());
+		request.addParameter("visit", visit.getUuid());
+		request.addParameter("fileCaption", fileCaption);
+		
+		// Replay
+		SimpleObject response = deserialize(handle(request));
+	}
+	
 	@Test
 	public void getAttachmentBytes_shouldDownloadFile() throws Exception {
 		


### PR DESCRIPTION
Basing on the discussion we had at https://talk.openmrs.org/t/attachment-functionality-of-openmrs-reference-application-is-vulnerable/33208/7.  

this functionality is to prevent upload of an executable or a script in order to prevent vulnerabilities in  this module.
I haven't created any ticket for this feature.  That is the reason why i haven't attached its link here.

cc @isears @HerbertYiga @sherrif10