### PR TITLE
RA-1875: Fixed patient dashboard with name as xss

### DIFF
--- a/omod/src/main/java/org/openmrs/module/attachments/fragment/controller/DashboardWidgetFragmentController.java
+++ b/omod/src/main/java/org/openmrs/module/attachments/fragment/controller/DashboardWidgetFragmentController.java
@@ -20,15 +20,12 @@ public class DashboardWidgetFragmentController {
 	
 	public void controller(FragmentModel model, @FragmentParam("patient") PatientDomainWrapper patientWrapper, UiUtils ui,
 	        @InjectBeans AttachmentsContext context) {
-		
 		// Ensure name is HTML-safe to prevent XSS in info messages
 		PersonName htmlSafePersonName = new PersonName(ui.escapeHtml(patientWrapper.getPatient().getGivenName()),
 		        ui.escapeHtml(patientWrapper.getPatient().getMiddleName()),
 		        ui.escapeHtml(patientWrapper.getPatient().getFamilyName()));
-		
 		patientWrapper.getPatient().removeName(patientWrapper.getPersonName());
 		patientWrapper.getPatient().addName(htmlSafePersonName);
-		
 		Map<String, Object> jsonConfig = ClientConfigFragmentController.getClientConfig(context, ui);
 		jsonConfig.put("patient", ConversionUtil.convertToRepresentation(patientWrapper.getPatient(), Representation.REF));
 		jsonConfig.put("thumbnailCount", context.getDashboardThumbnailCount());

--- a/omod/src/main/java/org/openmrs/module/attachments/fragment/controller/DashboardWidgetFragmentController.java
+++ b/omod/src/main/java/org/openmrs/module/attachments/fragment/controller/DashboardWidgetFragmentController.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.openmrs.PersonName;
 import org.openmrs.module.attachments.AttachmentsContext;
 import org.openmrs.module.emrapi.patient.PatientDomainWrapper;
 import org.openmrs.module.webservices.rest.web.ConversionUtil;
@@ -19,6 +20,15 @@ public class DashboardWidgetFragmentController {
 	
 	public void controller(FragmentModel model, @FragmentParam("patient") PatientDomainWrapper patientWrapper, UiUtils ui,
 	        @InjectBeans AttachmentsContext context) {
+		
+		// Ensure name is HTML-safe to prevent XSS in info messages
+		PersonName htmlSafePersonName = new PersonName(ui.escapeHtml(patientWrapper.getPatient().getGivenName()),
+		        ui.escapeHtml(patientWrapper.getPatient().getMiddleName()),
+		        ui.escapeHtml(patientWrapper.getPatient().getFamilyName()));
+		
+		patientWrapper.getPatient().removeName(patientWrapper.getPersonName());
+		patientWrapper.getPatient().addName(htmlSafePersonName);
+		
 		Map<String, Object> jsonConfig = ClientConfigFragmentController.getClientConfig(context, ui);
 		jsonConfig.put("patient", ConversionUtil.convertToRepresentation(patientWrapper.getPatient(), Representation.REF));
 		jsonConfig.put("thumbnailCount", context.getDashboardThumbnailCount());


### PR DESCRIPTION
# Description of what I changed
I added an HTML safe patient name and removed the current name from the set and added the new name to the set

# Issue I worked on
This was an issue where when adding a script to the name of a new patient than when you go to the patient dashboard the script is executed

# It can be reproduced following
1.) Create a patient with first name </script><script>alert(1)</script>
2.) Fill in the rest of the details with random data
3.) Navigate to the patient dashboard
4.) Should get a .js alert box on the patient dashboard

# Link to ticket
https://issues.openmrs.org/browse/RA-1875

@isears