### PR TITLE
(fix) Remove extra space in file size limit error message

### DIFF
--- a/omod/src/main/java/org/openmrs/module/attachments/rest/AttachmentResource.java
+++ b/omod/src/main/java/org/openmrs/module/attachments/rest/AttachmentResource.java
@@ -114,7 +114,7 @@ public class AttachmentResource extends DataDelegatingCrudResource<Attachment> i
 		}
 		// Verify File Size
 		if (ctx.getMaxUploadFileSize() * 1024 * 1024 < (double) file.getSize()) {
-			throw new IllegalRequestException("The file  exceeds the maximum size");
+			throw new IllegalRequestException("The file exceeds the maximum size");
 		}
 		
 		// Verify file extension


### PR DESCRIPTION
Removes an extra space from the error message returned when the uploaded file's size exceeds the allowable limit.