### PR TITLE
Capture `formFieldNamespace` and `formFieldPath` properties

### DIFF
--- a/api/src/main/java/org/openmrs/module/attachments/ComplexObsSaver.java
+++ b/api/src/main/java/org/openmrs/module/attachments/ComplexObsSaver.java
@@ -10,6 +10,7 @@
 package org.openmrs.module.attachments;
 
 import net.coobird.thumbnailator.Thumbnails;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.openmrs.ConceptComplex;
@@ -56,19 +57,24 @@ public class ComplexObsSaver {
 		return obs;
 	}
 
-	protected void prepareComplexObs(Visit visit, Person person, Encounter encounter, String fileCaption) {
+	protected void prepareComplexObs(Visit visit, Person person, Encounter encounter, String fileCaption,
+			String formFieldNamespace, String formFieldPath) {
 		obs = new Obs(person, conceptComplex,
 				visit == null || visit.getStopDatetime() == null ? new Date() : visit.getStopDatetime(),
 				encounter != null ? encounter.getLocation() : null);
 		obs.setEncounter(encounter); // may be null
 		obs.setComment(fileCaption);
+		if (StringUtils.isNotBlank(formFieldNamespace) && StringUtils.isNotBlank(formFieldPath)) {
+			obs.setFormField(formFieldNamespace, formFieldPath);
+		}
 	}
 
 	public Obs saveImageAttachment(Visit visit, Person person, Encounter encounter, String fileCaption,
-			MultipartFile multipartFile, String instructions) throws IOException {
+			MultipartFile multipartFile, String instructions, String formFieldNamespace, String formFieldPath)
+			throws IOException {
 
 		conceptComplex = context.getConceptComplex(ContentFamily.IMAGE);
-		prepareComplexObs(visit, person, encounter, fileCaption);
+		prepareComplexObs(visit, person, encounter, fileCaption, formFieldNamespace, formFieldPath);
 
 		Object image = multipartFile.getInputStream();
 		double compressionRatio = getCompressionRatio(multipartFile.getSize(),
@@ -85,9 +91,10 @@ public class ComplexObsSaver {
 	}
 
 	public Obs saveOtherAttachment(Visit visit, Person person, Encounter encounter, String fileCaption,
-			MultipartFile multipartFile, String instructions) throws IOException {
+			MultipartFile multipartFile, String instructions, String formFieldNamespace, String formFieldPath)
+			throws IOException {
 		conceptComplex = context.getConceptComplex(ContentFamily.OTHER);
-		prepareComplexObs(visit, person, encounter, fileCaption);
+		prepareComplexObs(visit, person, encounter, fileCaption, formFieldNamespace, formFieldPath);
 
 		obs.setComplexData(complexDataHelper.build(instructions, multipartFile.getOriginalFilename(),
 				multipartFile.getBytes(), multipartFile.getContentType()).asComplexData());

--- a/api/src/test/java/org/openmrs/module/attachments/obs/TestHelper.java
+++ b/api/src/test/java/org/openmrs/module/attachments/obs/TestHelper.java
@@ -184,7 +184,7 @@ public class TestHelper {
 
 		String fileCaption = RandomStringUtils.randomAlphabetic(12);
 		return obsSaver.saveOtherAttachment(visit, patient, encounter, fileCaption, getTestDefaultFile(),
-				ValueComplex.INSTRUCTIONS_DEFAULT);
+				ValueComplex.INSTRUCTIONS_DEFAULT, null, null);
 	}
 
 	/**
@@ -210,7 +210,7 @@ public class TestHelper {
 
 		String fileCaption = RandomStringUtils.randomAlphabetic(12);
 		return obsSaver.saveImageAttachment(visit, patient, encounter, fileCaption, lastSavedMultipartImageFile,
-				ValueComplex.INSTRUCTIONS_DEFAULT);
+				ValueComplex.INSTRUCTIONS_DEFAULT, null, null);
 	}
 
 	/**
@@ -237,7 +237,7 @@ public class TestHelper {
 
 		String fileCaption = RandomStringUtils.randomAlphabetic(12);
 		return obsSaver.saveOtherAttachment(null, patient, null, fileCaption, getTestDefaultFile(),
-				ValueComplex.INSTRUCTIONS_DEFAULT);
+				ValueComplex.INSTRUCTIONS_DEFAULT, null, null);
 	}
 
 	public String getComplexObsDir() {
@@ -279,7 +279,7 @@ public class TestHelper {
 			MockMultipartFile multipartRandomFile = new MockMultipartFile(FilenameUtils.getBaseName(filename), filename,
 					"application/octet-stream", randomData);
 			obsList.add(obsSaver.saveOtherAttachment(visit, patient, encounter, fileCaption, multipartRandomFile,
-					ValueComplex.INSTRUCTIONS_DEFAULT));
+					ValueComplex.INSTRUCTIONS_DEFAULT, null, null));
 		}
 
 		// Saves a complex obs as if they had been saved outside of Attachments

--- a/omod/src/main/java/org/openmrs/module/attachments/rest/AttachmentResource.java
+++ b/omod/src/main/java/org/openmrs/module/attachments/rest/AttachmentResource.java
@@ -117,6 +117,8 @@ public class AttachmentResource extends DataDelegatingCrudResource<Attachment> i
 		Encounter encounter = Context.getEncounterService().getEncounterByUuid(context.getParameter("encounter"));
 		Provider provider = Context.getProviderService().getProviderByUuid(context.getParameter("provider"));
 		String fileCaption = context.getParameter("fileCaption");
+		String formFieldNamespace = context.getParameter("formFieldNamespace");
+		String formFieldPath = context.getParameter("formFieldPath");
 		String instructions = context.getParameter("instructions");
 		String base64Content = context.getParameter("base64Content");
 
@@ -205,14 +207,16 @@ public class AttachmentResource extends DataDelegatingCrudResource<Attachment> i
 			case IMAGE :
 				obs = Context
 						.getRegisteredComponent(AttachmentsConstants.COMPONENT_COMPLEXOBS_SAVER, ComplexObsSaver.class)
-						.saveImageAttachment(visit, patient, encounter, fileCaption, file, instructions);
+						.saveImageAttachment(visit, patient, encounter, fileCaption, file, instructions,
+								formFieldNamespace, formFieldPath);
 				break;
 
 			case OTHER :
 			default :
 				obs = Context
 						.getRegisteredComponent(AttachmentsConstants.COMPONENT_COMPLEXOBS_SAVER, ComplexObsSaver.class)
-						.saveOtherAttachment(visit, patient, encounter, fileCaption, file, instructions);
+						.saveOtherAttachment(visit, patient, encounter, fileCaption, file, instructions,
+								formFieldNamespace, formFieldPath);
 				break;
 		}
 


### PR DESCRIPTION
Adds the ability to capture the form field path, allowing us to map an attachment to its corresponding form field. 