### PR TITLE
ATT-64: Upgrade tika-core to 3.2.2 and fix deprecated Mockito import

### DIFF
--- a/api/src/test/java/org/openmrs/module/attachments/AttachmentsContextTest.java
+++ b/api/src/test/java/org/openmrs/module/attachments/AttachmentsContextTest.java
@@ -1,7 +1,7 @@
 package org.openmrs.module.attachments;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -148,7 +148,7 @@
 	    <dependency>
 		    <groupId>org.apache.tika</groupId>
 		    <artifactId>tika-core</artifactId>
-		    <version>2.9.2</version>
+		    <version>3.2.2</version>
 		    <exclusions>
 		    	<exclusion>
 		    		<groupId>org.slf4j</groupId>


### PR DESCRIPTION
## Summary
Upgrades `org.apache.tika:tika-core` from 2.9.2 to 3.2.2 in `omod/pom.xml` to address the security vulnerability ([GHSA-f58c-gq56-vjjf](https://github.com/advisories/GHSA-f58c-gq56-vjjf)). Also includes a small Mockito cleanup in the test code.

Fixes: [ATT-64](https://openmrs.atlassian.net/browse/ATT-64)

## Changes

### 1. `omod/pom.xml`
- Bumped `tika-core` dependency from `2.9.2` → `3.2.2`

### 2. `api/src/test/.../AttachmentsContextTest.java`
- Migrated deprecated `org.mockito.Matchers` → `org.mockito.ArgumentMatchers`
- **Note:** This is a standard Mockito cleanup, _not_ caused by the Tika upgrade. Tika does not transitively pull in Mockito — Mockito comes from OpenMRS Core test dependencies.

## Verification
- **Build:** `mvn clean package` passes ✅
- **Integration tests:** `AttachmentResourceIntegrationTest` - 3/3 pass ✅ (exercises Tika MIME detection)  
- **Unit tests:** `AttachmentsContextTest` - 2/2 pass ✅
- **Module loading:** Confirmed module loads on OpenMRS 2.8.4 - liquibase migrations run successfully

## API Compatibility
All Tika APIs used in `AttachmentResource.java` (lines 170-185) are confirmed present and unchanged in Tika 3.x:
- `new Tika()`, `tika.detect(InputStream)`
- `MimeTypes.getDefaultMimeTypes()`, `MimeType.forName()`, `MimeType.getExtensions()`

## Note on Java Compatibility
Tika 3.2.2 requires JDK 11+. OpenMRS Platform 2.8.x already requires Java 11+, so this should not cause runtime issues for supported deployments. However, per @ibacher's feedback, the preferred approach may be to scope this upgrade to a 5.x major version of the module. Happy to adjust based on maintainer preference.

## Related
- Supersedes PR #83 (contained unrelated `@Verifies` annotation removal)


[ATT-64]: https://openmrs.atlassian.net/browse/ATT-64?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ