### PR TITLE
ATT-64: [5.x] Upgrade tika-core to 3.2.2, require Java 11+, and bump to 5.0.0-SNAPSHOT

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,9 @@ concurrency:
 jobs:
   build:
     uses: openmrs/openmrs-contrib-gha-workflows/.github/workflows/build-backend-module.yml@main
+    with:
+      java_versions: '["11"]'
+      main_java_version: '11'
     secrets:
       MAVEN_REPO_USERNAME: ${{ secrets.MAVEN_REPO_USERNAME }}
       MAVEN_REPO_API_KEY: ${{ secrets.MAVEN_REPO_API_KEY }}

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openmrs.module</groupId>
 		<artifactId>attachments</artifactId>
-		<version>4.1.0-SNAPSHOT</version>
+		<version>5.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>attachments-api</artifactId>

--- a/api/src/test/java/org/openmrs/module/attachments/AttachmentsContextTest.java
+++ b/api/src/test/java/org/openmrs/module/attachments/AttachmentsContextTest.java
@@ -1,7 +1,7 @@
 package org.openmrs.module.attachments;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -148,7 +148,7 @@
 	    <dependency>
 		    <groupId>org.apache.tika</groupId>
 		    <artifactId>tika-core</artifactId>
-		    <version>2.9.2</version>
+		    <version>3.2.2</version>
 		    <exclusions>
 		    	<exclusion>
 		    		<groupId>org.slf4j</groupId>

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.openmrs.module</groupId>
 		<artifactId>attachments</artifactId>
-		<version>4.1.0-SNAPSHOT</version>
+		<version>5.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>attachments-omod</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.openmrs.module</groupId>
   <artifactId>attachments</artifactId>
-  <version>4.1.0-SNAPSHOT</version>
+  <version>5.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Attachments</name>
   <description>
@@ -124,8 +124,8 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <configuration>
-            <target>8</target>
-            <source>8</source>
+            <target>11</target>
+            <source>11</source>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
## Summary
This PR follows @ibacher's suggestion to create a 5.x version line targeting Java 11+ to accommodate the Tika 3.x upgrade. Tika 3.2.2 is the lowest version that remediates CVE-2024-28752 ([GHSA-f58c-gq56-vjjf](https://github.com/advisories/GHSA-f58c-gq56-vjjf)), but it requires Java 11.

Fixes: [ATT-64](https://openmrs.atlassian.net/browse/ATT-64)
Supersedes the 4.x PR attempt.

## Changes
1. **Version Bump:** Bumped module version across POMs from `4.1.0-SNAPSHOT` to `5.0.0-SNAPSHOT`.
2. **Java Baseline:** Updated `maven-compiler-plugin` target/source to `11` in `pom.xml`.
3. **CI Config:** Updated `.github/workflows/build.yml` to compile/test using Java 11 instead of 8.
4. **Tika Upgrade:** Upgraded `org.apache.tika:tika-core` to `3.2.2` in `omod/pom.xml`.
5. **Mockito Fix:** Replaced deprecated `Matchers` with `ArgumentMatchers` in `AttachmentsContextTest` to avoid build failure (this is standard test cleanup, unrelated to Tika).

## API Compatibility
All Tika APIs used in `AttachmentResource.java` are confirmed present and unchanged in Tika 3.x:
- `new Tika()`, `tika.detect(InputStream)`
- `MimeTypes.getDefaultMimeTypes()`, `MimeType.forName()`, `MimeType.getExtensions()`

## Verification
- Local build `mvn clean package` passes 100% ✅
- `AttachmentResourceIntegrationTest` all pass (properly exercising Tika MIME logic) ✅


<img width="838" height="275" alt="Screenshot 2026-03-20 231048" src="https://github.com/user-attachments/assets/df8e00d2-6cf0-46e0-bcd1-644b47eaccca" />


[ATT-64]: https://openmrs.atlassian.net/browse/ATT-64?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ