### PR TITLE
Fixes ATT-64.Upgrade org.apache.tika:tika-core from 2.9.2 to 3.2.2 in /omod and fix build issues

### DIFF
--- a/api/src/test/java/org/openmrs/module/attachments/AttachmentsContextTest.java
+++ b/api/src/test/java/org/openmrs/module/attachments/AttachmentsContextTest.java
@@ -1,7 +1,7 @@
 package org.openmrs.module.attachments;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -148,7 +148,7 @@
 	    <dependency>
 		    <groupId>org.apache.tika</groupId>
 		    <artifactId>tika-core</artifactId>
-		    <version>2.9.2</version>
+		    <version>3.2.2</version>
 		    <exclusions>
 		    	<exclusion>
 		    		<groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -124,8 +124,7 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <configuration>
-            <target>8</target>
-            <source>8</source>
+            <release>11</release>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
## Summary
Fixes ATT-64: Upgrades tika-core from 2.9.2 to 3.2.2 to address 
known security vulnerabilities (CVE-2024-28752).

## Root Cause
Tika 3.x is compiled with Java 11 (class file version 55.0). 
The project previously targeted Java 8 (52.0), causing a 
class file version incompatibility at compile time.

## Changes
- omod/pom.xml: Upgraded tika-core 2.9.2 → 3.2.2
- pom.xml: Updated maven-compiler-plugin to use <release>11</release>
  instead of <source>/<target> tags. The <release> flag is preferred 
  as it prevents accidental use of JDK APIs unavailable in Java 11.
- .github/workflows/build.yml: Updated CI to build with Java 11
- AttachmentsContextTest.java: Replaced deprecated 
  org.mockito.Matchers with org.mockito.ArgumentMatchers

## Testing
- mvn clean install -DskipTests passes 
- All modules compile successfully 

Fixes: ATT-64



<img width="700" height="216" alt="image" src="https://github.com/user-attachments/assets/30865680-a500-4e74-93fc-ef4410e78b90" />
