### PR TITLE
ATT-64: Upgrade tika-core to 3.2.2 and fix build issues

### DIFF
--- a/api/src/test/java/org/openmrs/module/attachments/AttachmentsContextTest.java
+++ b/api/src/test/java/org/openmrs/module/attachments/AttachmentsContextTest.java
@@ -1,7 +1,7 @@
 package org.openmrs.module.attachments;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -148,7 +148,7 @@
 	    <dependency>
 		    <groupId>org.apache.tika</groupId>
 		    <artifactId>tika-core</artifactId>
-		    <version>2.9.2</version>
+		    <version>3.2.2</version>
 		    <exclusions>
 		    	<exclusion>
 		    		<groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -124,8 +124,8 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <configuration>
-            <target>8</target>
-            <source>8</source>
+            <target>11</target>
+            <source>11</source>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
## Summary
Closes ATT-64

Upgrades `org.apache.tika:tika-core` from `2.9.2` to `3.2.2` in `/omod` to 
address known security vulnerabilities. This PR also fixes the compilation 
issues introduced by the Tika 3.x upgrade and modernizes the build to require 
Java 11+.

---

## Changes Made

### 1. `omod/pom.xml`
- Upgraded `org.apache.tika:tika-core` from `2.9.2` → `3.2.2`

### 2. `pom.xml`
- Updated `maven-compiler-plugin` source/target from `8` → `11`
- This is required as Tika 3.x dropped support for Java 8

### 3. `api/src/test/java/.../AttachmentsContextTest.java`
- Fixed deprecated Mockito import:
  - `org.mockito.Matchers.eq` → `org.mockito.ArgumentMatchers.eq`
  - `Matchers` was removed in newer Mockito versions, 
     `ArgumentMatchers` is the correct replacement

---

## Root Cause of Build Failure
The original upgrade attempt failed due to two issues:
1. Tika 3.x requires **Java 11+** — the project was still configured for Java 8
2. Mockito's `org.mockito.Matchers` was deprecated and removed, causing 
   test compilation to fail

---

## Type of Change
- [ ] Bug fix
- [x] Dependency upgrade (security)
- [x] Build improvement
- [ ] New feature
- [ ] Breaking change

---

## How Has This Been Tested?

### Build Verification
- Compiled using **Java 11** with `mvn clean install`
- All 3 reactor modules build successfully:
  - ✅ Attachments (parent)
  - ✅ Attachments API
  - ✅ Attachments OMOD

### Runtime Verification
- Deployed `attachments-4.1.0-SNAPSHOT.omod` to a local OpenMRS SDK 
  server running **OpenMRS 2.8.4**
- Verified module starts successfully in Admin → Manage Modules
- Manually tested file upload functionality:
  - ✅ PDF upload works
  - ✅ Image upload works
  - ✅ Files visible in patient chart
  - ✅ No Tika-related errors in `openmrs.log`

---

## Screenshots
### Build Success with Java 11
<img width="1137" height="412" alt="Screenshot_2026-03-23_13-21-05" src="https://github.com/user-attachments/assets/87148358-d224-4b9b-871d-4b094255d9c1" />

### Module Running on OpenMRS
<img width="2321" height="752" alt="Screenshot_2026-03-23_13-23-23" src="https://github.com/user-attachments/assets/baaa2d13-4288-4a3a-add8-600dfd6071f5" />

### File Upload Working
<img width="2860" height="1362" alt="Screenshot_2026-03-23_13-23-50" src="https://github.com/user-attachments/assets/d0e8c676-e30b-47c1-a373-38b965512440" />


---

## Checklist
- [x] My code follows the OpenMRS code style
- [x] I have performed a self-review of my own code
- [x] The build passes (`mvn clean install`)
- [x] All existing tests pass
- [x] I have tested this manually on a running OpenMRS instance
- [x] No new vulnerabilities introduced
- [x] Changes are minimal and follow project standards

---

## Related
- JIRA: [ATT-64](https://issues.openmrs.org/browse/ATT-64)
- Tika 3.x Changelogs: https://tika.apache.org/3.2.2/index.html
## Note
This PR addresses the same issue as #85 but takes a more minimal approach —
only upgrading the Tika dependency and fixing the immediate compilation issues
(3 files, 4 lines changed) without additional scope changes.

Tested by deploying `attachments-4.1.0-SNAPSHOT.omod` to a local OpenMRS SDK 
server (OpenMRS 2.8.4) using `mvn openmrs-sdk:deploy -DserverId=server1` and 
manually verified file upload functionality works end to end.

[ATT-64]: https://openmrs.atlassian.net/browse/ATT-64?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ