### PR TITLE
Upgrade org.apache.tika:tika-core from 2.9.2 to 3.2.2 in /omod and fix build issues

### DIFF
--- a/api/src/test/java/org/openmrs/module/attachments/AttachmentsContextTest.java
+++ b/api/src/test/java/org/openmrs/module/attachments/AttachmentsContextTest.java
@@ -1,7 +1,7 @@
 package org.openmrs.module.attachments;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -148,7 +148,7 @@
 	    <dependency>
 		    <groupId>org.apache.tika</groupId>
 		    <artifactId>tika-core</artifactId>
-		    <version>2.9.2</version>
+		    <version>3.2.2</version>
 		    <exclusions>
 		    	<exclusion>
 		    		<groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -124,8 +124,8 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <configuration>
-            <target>8</target>
-            <source>8</source>
+            <target>11</target>
+            <source>11</source>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
This pull request updates dependencies and build configuration to modernize the project and ensure compatibility with newer Java and library versions. The most important changes are:

**Build and Java version updates:**

* Updated the Maven compiler plugin configuration in `pom.xml` to use Java 11 as the source and target version, instead of Java 8.

**Dependency updates:**

* Upgraded the `tika-core` dependency in `omod/pom.xml` from version 2.9.2 to 3.2.2.

**Test and import improvements:**

* Updated the static import in `AttachmentsContextTest.java` to use `org.mockito.ArgumentMatchers.eq` instead of the deprecated `org.mockito.Matchers.eq`.